### PR TITLE
Small cleanup items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        api-level: [21, 29]
+        api-level: [21, 22, 23, 24, 25, 26, 27, 28, 29]
 
     steps:
       - name: Check out the repo

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ allprojects { project ->
     //noinspection UnnecessaryQualifiedReference
     project.plugins.withType(com.android.build.gradle.LibraryPlugin) {
         project.android.libraryVariants.all { variant ->
-            // TODO replace with https://issuetracker.google.com/issues/72050365 once released.
+            // TODO WORKAROUND: replace with https://issuetracker.google.com/issues/72050365 once released.
             variant.generateBuildConfigProvider.get().enabled = false
         }
     }
@@ -57,12 +57,12 @@ ext {
     libraryVersion = '2.0.0-SNAPSHOT'
 
     minSdkVersion = 15
-    compileSdkVersion = 28
+    compileSdkVersion = 29
 
-    keystore = project.hasProperty('personalKeystore') ? personalKeystore : 'dummy'
-    keystorePassword = project.hasProperty('personalKeystorePassword') ? personalKeystorePassword : 'dummy'
-    keyAlias = project.hasProperty('personalKeyAlias') ? personalKeyAlias : 'dummy'
-    keyPassword = project.hasProperty('personalKeyPassword') ? personalKeyPassword : 'dummy'
+    keystore = project.hasProperty('personalKeystore') ? personalKeystore : 'x'
+    keystorePassword = project.hasProperty('personalKeystorePassword') ? personalKeystorePassword : 'x'
+    keyAlias = project.hasProperty('personalKeyAlias') ? personalKeyAlias : 'x'
+    keyPassword = project.hasProperty('personalKeyPassword') ? personalKeyPassword : 'x'
 }
 
 task clean(type: Delete) {

--- a/javatime/src/androidTest/java/dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatterTest.kt
@@ -13,6 +13,9 @@ import java.util.Locale
 @RequiresApi(21) // Instrumented tests for Dynamic Features is not supported on API < 21 (AGP 4.0.0-beta04)
 class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
+    private val expectedFormattedTime: String
+        get() = androidTimeFormatInUtc.format(LEGACY_TIME)
+
     @Test fun ofLocalizedTime_nullSystemSettingUsLocale_uses12HourFormat() {
         assumeFalse(
             "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
@@ -28,7 +31,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_12SystemSettingUsLocale_uses12HourFormat() {
-        systemTimeSetting = "12"
+        systemTimeSetting = TIME_SETTING_12
         testLocale = Locale.US
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
@@ -37,7 +40,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_24SystemSettingUsLocale_uses24HourFormat() {
-        systemTimeSetting = "24"
+        systemTimeSetting = TIME_SETTING_24
         testLocale = Locale.US
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
@@ -60,7 +63,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_12SystemSettingItalyLocale_uses12HourFormat() {
-        systemTimeSetting = "12"
+        systemTimeSetting = TIME_SETTING_12
         testLocale = Locale.ITALY
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
@@ -69,7 +72,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_24SystemSettingItalyLocale_uses24HourFormat() {
-        systemTimeSetting = "24"
+        systemTimeSetting = TIME_SETTING_24
         testLocale = Locale.ITALY
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
@@ -77,12 +80,8 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         assertEquals(expectedFormattedTime, formattedTime)
     }
 
-    private val expectedFormattedTime get(): String = androidTimeFormatInUtc.format(LEGACY_TIME)
-
     private companion object {
-        private const val SDK_INT_NULLABLE_TIME_SETTING = 28
-
         private val TIME = LocalTime.of(16, 44)
-        private val LEGACY_TIME: Date = timeFormat24InUtc.parse("16:44")!!
+        private val LEGACY_TIME: Date = TIME_FORMAT_24_IN_UTC.parse("16:44")!!
     }
 }

--- a/javatime/src/androidTest/java/dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatterTest.kt
@@ -1,10 +1,10 @@
 package dev.drewhamilton.androiddatetimeformatters.javatime
 
 import android.os.Build
-import android.util.Log
 import androidx.annotation.RequiresApi
 import dev.drewhamilton.androiddatetimeformatters.test.TimeSettingTest
 import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeFalse
 import org.junit.Test
 import java.time.LocalTime
 import java.util.Date
@@ -14,10 +14,10 @@ import java.util.Locale
 class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
     @Test fun ofLocalizedTime_nullSystemSettingUsLocale_uses12HourFormat() {
-        if (Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING) {
-            Log.i(TAG, "Time setting is not nullable in API ${Build.VERSION.SDK_INT}")
-            return
-        }
+        assumeFalse(
+            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
+            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
+        )
 
         systemTimeSetting = null
         testLocale = Locale.US
@@ -46,10 +46,10 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_nullSystemSettingItalyLocale_uses24HourFormat() {
-        if (Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING) {
-            Log.i(TAG, "Time setting is not nullable in API ${Build.VERSION.SDK_INT}")
-            return
-        }
+        assumeFalse(
+            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
+            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
+        )
 
         systemTimeSetting = null
         testLocale = Locale.ITALY
@@ -80,12 +80,9 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     private val expectedFormattedTime get(): String = androidTimeFormatInUtc.format(LEGACY_TIME)
 
     private companion object {
-        private val TAG = AndroidDateTimeFormatterTest::class.java.simpleName
-
         private const val SDK_INT_NULLABLE_TIME_SETTING = 28
 
         private val TIME = LocalTime.of(16, 44)
-
-        @JvmStatic private val LEGACY_TIME: Date = timeFormat24InUtc.parse("16:44")
+        private val LEGACY_TIME: Date = timeFormat24InUtc.parse("16:44")!!
     }
 }

--- a/javatime/src/main/java/dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatter.java
@@ -33,7 +33,12 @@ public final class AndroidDateTimeFormatter {
                     .appendPattern(pattern)
                     .toFormatter(extractLocale(context));
         } else {
-            throw new IllegalArgumentException("Unable to convert DateFormat to DateTimeFormatter");
+            // DateFormat.getTimeFormat is hard-coded to be a SimpleDateFormat instance, so this should never happen:
+            String errorMessage = String.format(
+                    Locale.US,
+                    "Expected Android time format to be %s, but it was %s",
+                    SimpleDateFormat.class.getName(), legacyFormat.getClass().getName());
+            throw new IllegalStateException(errorMessage);
         }
     }
 

--- a/javatime/src/main/java/dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatter.java
@@ -40,7 +40,7 @@ public final class AndroidDateTimeFormatter {
     private static Locale extractLocale(Context context) {
         Configuration configuration = context.getResources().getConfiguration();
         Locale locale = null;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        if (Build.VERSION.SDK_INT >= 24) {
             LocaleList localeList = configuration.getLocales();
             if (!localeList.isEmpty()) {
                 locale = localeList.get(0);

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     api deps.androidTestRules
 
     implementation deps.kotlinStdLib
+    implementation 'androidx.core:core:1.2.0'
 }

--- a/test/src/main/java/dev/drewhamilton/androiddatetimeformatters/test/TimeSettingTest.kt
+++ b/test/src/main/java/dev/drewhamilton/androiddatetimeformatters/test/TimeSettingTest.kt
@@ -9,7 +9,6 @@ import androidx.core.os.ConfigurationCompat
 import androidx.core.os.LocaleListCompat
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
-import org.junit.Assume.assumeTrue
 import org.junit.Before
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -91,8 +90,8 @@ abstract class TimeSettingTest {
         } else {
             val originalLocale = originalLocales[0]
             val timeFormat = DateFormat.getTimeInstance(DateFormat.SHORT, originalLocale)
-            val formattedTime = timeFormat.format(tenPm)
-            systemTimeSetting = if (formattedTime.contains("22")) "24" else "12"
+            val formattedTime = timeFormat.format(TEN_PM)
+            systemTimeSetting = if (formattedTime.contains("22")) TIME_SETTING_24 else TIME_SETTING_12
         }
     }
 
@@ -100,28 +99,20 @@ abstract class TimeSettingTest {
         systemTimeSetting = originalTimeSetting
     }
 
-    /**
-     * Ignore the test in progress if [block] throws an instance of [E].
-     */
-    private inline fun <reified E : Exception> ignoreIfThrowing(block: () -> Unit) {
-        try {
-            block()
-        } catch (exception: Exception) {
-            if (exception is E)
-                assumeTrue("Test ignored: ${exception.message}", false)
-            else
-                throw exception
-        }
-    }
-
     protected companion object {
         private val TAG = TimeSettingTest::class.java.simpleName
 
-        @JvmStatic val timeFormat24InUtc: DateFormat
-            get() = SimpleDateFormat("HH:mm", Locale.US).apply {
+        const val SDK_INT_NULLABLE_TIME_SETTING = 28
+
+        const val TIME_SETTING_12 = "12"
+        const val TIME_SETTING_24 = "24"
+
+        val TIME_FORMAT_24_IN_UTC: DateFormat by lazy {
+            SimpleDateFormat("HH:mm", Locale.US).apply {
                 timeZone = TimeZone.getTimeZone("UTC")
             }
+        }
 
-        private val tenPm = timeFormat24InUtc.parse("22:00")
+        private val TEN_PM = TIME_FORMAT_24_IN_UTC.parse("22:00")
     }
 }

--- a/threetenbp/src/androidTest/java/dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatterTest.kt
+++ b/threetenbp/src/androidTest/java/dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatterTest.kt
@@ -11,6 +11,9 @@ import java.util.Locale
 
 class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
+    private val expectedFormattedTime: String
+        get() = androidTimeFormatInUtc.format(LEGACY_TIME)
+
     @Test fun ofLocalizedTime_nullSystemSettingUsLocale_uses12HourFormat() {
         assumeFalse(
             "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
@@ -26,7 +29,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_12SystemSettingUsLocale_uses12HourFormat() {
-        systemTimeSetting = "12"
+        systemTimeSetting = TIME_SETTING_12
         testLocale = Locale.US
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
@@ -35,7 +38,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_24SystemSettingUsLocale_uses24HourFormat() {
-        systemTimeSetting = "24"
+        systemTimeSetting = TIME_SETTING_24
         testLocale = Locale.US
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
@@ -58,7 +61,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_12SystemSettingItalyLocale_uses12HourFormat() {
-        systemTimeSetting = "12"
+        systemTimeSetting = TIME_SETTING_12
         testLocale = Locale.ITALY
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
@@ -67,7 +70,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_24SystemSettingItalyLocale_uses24HourFormat() {
-        systemTimeSetting = "24"
+        systemTimeSetting = TIME_SETTING_24
         testLocale = Locale.ITALY
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
@@ -75,12 +78,8 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         assertEquals(expectedFormattedTime, formattedTime)
     }
 
-    private val expectedFormattedTime get(): String = androidTimeFormatInUtc.format(LEGACY_TIME)
-
     private companion object {
-        private const val SDK_INT_NULLABLE_TIME_SETTING = 28
-
         private val TIME = LocalTime.of(16, 44)
-        private val LEGACY_TIME: Date = timeFormat24InUtc.parse("16:44")!!
+        private val LEGACY_TIME: Date = TIME_FORMAT_24_IN_UTC.parse("16:44")!!
     }
 }

--- a/threetenbp/src/androidTest/java/dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatterTest.kt
+++ b/threetenbp/src/androidTest/java/dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatterTest.kt
@@ -1,9 +1,9 @@
 package dev.drewhamilton.androiddatetimeformatters.threetenbp
 
 import android.os.Build
-import android.util.Log
 import dev.drewhamilton.androiddatetimeformatters.test.TimeSettingTest
 import org.junit.Assert.assertEquals
+import org.junit.Assume.assumeFalse
 import org.junit.Test
 import org.threeten.bp.LocalTime
 import java.util.Date
@@ -12,10 +12,10 @@ import java.util.Locale
 class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
     @Test fun ofLocalizedTime_nullSystemSettingUsLocale_uses12HourFormat() {
-        if (Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING) {
-            Log.i(TAG, "Time setting is not nullable in API ${Build.VERSION.SDK_INT}")
-            return
-        }
+        assumeFalse(
+            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
+            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
+        )
 
         systemTimeSetting = null
         testLocale = Locale.US
@@ -44,10 +44,10 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_nullSystemSettingItalyLocale_uses24HourFormat() {
-        if (Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING) {
-            Log.i(TAG, "Time setting is not nullable in API ${Build.VERSION.SDK_INT}")
-            return
-        }
+        assumeFalse(
+            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
+            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
+        )
 
         systemTimeSetting = null
         testLocale = Locale.ITALY
@@ -78,11 +78,9 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     private val expectedFormattedTime get(): String = androidTimeFormatInUtc.format(LEGACY_TIME)
 
     private companion object {
-        private val TAG = AndroidDateTimeFormatterTest::class.java.simpleName
-
         private const val SDK_INT_NULLABLE_TIME_SETTING = 28
 
         private val TIME = LocalTime.of(16, 44)
-        @JvmStatic private val LEGACY_TIME: Date = timeFormat24InUtc.parse("16:44")
+        private val LEGACY_TIME: Date = timeFormat24InUtc.parse("16:44")!!
     }
 }

--- a/threetenbp/src/main/java/dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatter.java
+++ b/threetenbp/src/main/java/dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatter.java
@@ -34,7 +34,12 @@ public final class AndroidDateTimeFormatter {
                     .appendPattern(pattern)
                     .toFormatter(extractLocale(context));
         } else {
-            throw new IllegalArgumentException("Unable to convert DateFormat to DateTimeFormatter");
+            // DateFormat.getTimeFormat is hard-coded to be a SimpleDateFormat instance, so this should never happen:
+            String errorMessage = String.format(
+                    Locale.US,
+                    "Expected Android time format to be %s, but it was %s",
+                    SimpleDateFormat.class.getName(), legacyFormat.getClass().getName());
+            throw new IllegalStateException(errorMessage);
         }
     }
 

--- a/threetenbp/src/main/java/dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatter.java
+++ b/threetenbp/src/main/java/dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatter.java
@@ -41,7 +41,7 @@ public final class AndroidDateTimeFormatter {
     private static Locale extractLocale(Context context) {
         Configuration configuration = context.getResources().getConfiguration();
         Locale locale = null;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        if (Build.VERSION.SDK_INT >= 24) {
             LocaleList localeList = configuration.getLocales();
             if (!localeList.isEmpty()) {
                 locale = localeList.get(0);


### PR DESCRIPTION
* Compile to API 29
* Ensure tests are ignored rather than passing or failing on unsupported devices
* Better error messages on the impossible wrong-date-format case