### PR TITLE
Change to shorter, more generic package name.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId "dev.drewhamilton.androiddatetimeformatters.demo"
+        applicationId "dev.drewhamilton.androidtime.format.demo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.compileSdkVersion
         versionCode 1

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="dev.drewhamilton.androiddatetimeformatters.demo">
+    package="dev.drewhamilton.androidtime.format.demo">
 
   <application
       android:name=".DemoApp"

--- a/app/src/main/java/dev/drewhamilton/androidtime/format/demo/Demo.java
+++ b/app/src/main/java/dev/drewhamilton/androidtime/format/demo/Demo.java
@@ -1,4 +1,4 @@
-package dev.drewhamilton.androiddatetimeformatters.demo;
+package dev.drewhamilton.androidtime.format.demo;
 
 import android.os.Bundle;
 import android.widget.TextView;
@@ -9,7 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
-import dev.drewhamilton.androiddatetimeformatters.javatime.AndroidDateTimeFormatter;
+import dev.drewhamilton.androidtime.format.AndroidDateTimeFormatter;
 
 public class Demo extends AppCompatActivity {
 
@@ -35,7 +35,7 @@ public class Demo extends AppCompatActivity {
     private void displayThreeTenBpTime() {
         TextView threeTenBpValue = findViewById(R.id.threeTenBpValue);
         org.threeten.bp.format.DateTimeFormatter formatter =
-                dev.drewhamilton.androiddatetimeformatters.threetenbp.AndroidDateTimeFormatter
+                dev.drewhamilton.androidtime.threetenbp.format.AndroidDateTimeFormatter
                         .ofLocalizedTime(getApplicationContext());
         threeTenBpValue.setText(formatter.format(org.threeten.bp.LocalTime.now()));
     }

--- a/app/src/main/java/dev/drewhamilton/androidtime/format/demo/DemoApp.java
+++ b/app/src/main/java/dev/drewhamilton/androidtime/format/demo/DemoApp.java
@@ -1,4 +1,4 @@
-package dev.drewhamilton.androiddatetimeformatters.demo;
+package dev.drewhamilton.androidtime.format.demo;
 
 import androidx.multidex.MultiDexApplication;
 

--- a/javatime/api/javatime.api
+++ b/javatime/api/javatime.api
@@ -1,4 +1,4 @@
-public final class dev/drewhamilton/androiddatetimeformatters/javatime/AndroidDateTimeFormatter {
+public final class dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter {
 	public static fun ofLocalizedTime (Landroid/content/Context;)Ljava/time/format/DateTimeFormatter;
 }
 

--- a/javatime/src/androidTest/AndroidManifest.xml
+++ b/javatime/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.drewhamilton.androiddatetimeformatters.javatime.test">
+    package="dev.drewhamilton.androidtime.format.test">
 
   <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -1,14 +1,16 @@
-package dev.drewhamilton.androiddatetimeformatters.threetenbp
+package dev.drewhamilton.androidtime.format
 
 import android.os.Build
-import dev.drewhamilton.androiddatetimeformatters.test.TimeSettingTest
+import androidx.annotation.RequiresApi
+import dev.drewhamilton.androidtime.format.test.TimeSettingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assume.assumeFalse
 import org.junit.Test
-import org.threeten.bp.LocalTime
+import java.time.LocalTime
 import java.util.Date
 import java.util.Locale
 
+@RequiresApi(21) // Instrumented tests for Dynamic Features is not supported on API < 21 (AGP 4.0.0-beta04)
 class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
     private val expectedFormattedTime: String

--- a/javatime/src/main/AndroidManifest.xml
+++ b/javatime/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.drewhamilton.androiddatetimeformatters.javatime" />
+    package="dev.drewhamilton.androidtime.format" />

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -1,4 +1,4 @@
-package dev.drewhamilton.androiddatetimeformatters.javatime;
+package dev.drewhamilton.androidtime.format;
 
 import android.content.Context;
 import android.content.res.Configuration;

--- a/test/src/main/AndroidManifest.xml
+++ b/test/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.drewhamilton.androiddatetimeformatters.test" />
+    package="dev.drewhamilton.androidtime.format.test" />

--- a/test/src/main/java/dev/drewhamilton/androidtime/format/test/TimeSettingTest.kt
+++ b/test/src/main/java/dev/drewhamilton/androidtime/format/test/TimeSettingTest.kt
@@ -1,4 +1,4 @@
-package dev.drewhamilton.androiddatetimeformatters.test
+package dev.drewhamilton.androidtime.format.test
 
 import android.content.Context
 import android.os.Build

--- a/threetenbp/api/threetenbp.api
+++ b/threetenbp/api/threetenbp.api
@@ -1,4 +1,4 @@
-public final class dev/drewhamilton/androiddatetimeformatters/threetenbp/AndroidDateTimeFormatter {
+public final class dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter {
 	public static fun ofLocalizedTime (Landroid/content/Context;)Lorg/threeten/bp/format/DateTimeFormatter;
 }
 

--- a/threetenbp/src/androidTest/AndroidManifest.xml
+++ b/threetenbp/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.drewhamilton.androiddatetimeformatters.threetenbp.test">
+    package="dev.drewhamilton.androidtime.threetenbp.format.test">
 
   <uses-permission android:name="android.permission.WRITE_SETTINGS" />
 

--- a/threetenbp/src/androidTest/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatterTest.kt
+++ b/threetenbp/src/androidTest/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatterTest.kt
@@ -1,16 +1,14 @@
-package dev.drewhamilton.androiddatetimeformatters.javatime
+package dev.drewhamilton.androidtime.threetenbp.format
 
 import android.os.Build
-import androidx.annotation.RequiresApi
-import dev.drewhamilton.androiddatetimeformatters.test.TimeSettingTest
+import dev.drewhamilton.androidtime.format.test.TimeSettingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assume.assumeFalse
 import org.junit.Test
-import java.time.LocalTime
+import org.threeten.bp.LocalTime
 import java.util.Date
 import java.util.Locale
 
-@RequiresApi(21) // Instrumented tests for Dynamic Features is not supported on API < 21 (AGP 4.0.0-beta04)
 class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
     private val expectedFormattedTime: String

--- a/threetenbp/src/main/AndroidManifest.xml
+++ b/threetenbp/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="dev.drewhamilton.androiddatetimeformatters.threetenbp" />
+    package="dev.drewhamilton.androidtime.threetenbp.format" />

--- a/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
+++ b/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
@@ -1,4 +1,4 @@
-package dev.drewhamilton.androiddatetimeformatters.threetenbp;
+package dev.drewhamilton.androidtime.threetenbp.format;
 
 import android.content.Context;
 import android.content.res.Configuration;


### PR DESCRIPTION
`dev.drewhamilton.androiddatetimeformatters.threetenbp` was long and hard to read.

`dev.drewhamilton.androidtime.threetenbp.format` is a bit shorter and easier to read.