### PR TITLE
Lower java.time minSdk

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.compileSdk
     defaultConfig {
         applicationId "dev.drewhamilton.androidtime.format.demo"
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.compileSdkVersion
+        minSdkVersion rootProject.ext.threeTenAbpMinSdk
+        targetSdkVersion rootProject.ext.compileSdk
         versionCode 1
         versionName rootProject.ext.libraryVersion
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // Support core library desugaring:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,10 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
         coreLibraryDesugaringEnabled true
     }
+
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion rootProject.ext.compileSdk
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
     defaultConfig {
         applicationId "dev.drewhamilton.androidtime.format.demo"
         minSdkVersion rootProject.ext.threeTenAbpMinSdk

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,5 +44,4 @@ dependencies {
     coreLibraryDesugaring deps.desugarJdkLibs
 
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
 }

--- a/app/src/main/java/dev/drewhamilton/androidtime/format/demo/Demo.java
+++ b/app/src/main/java/dev/drewhamilton/androidtime/format/demo/Demo.java
@@ -1,7 +1,6 @@
 package dev.drewhamilton.androidtime.format.demo;
 
 import android.os.Bundle;
-import android.widget.TextView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -10,13 +9,17 @@ import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 import dev.drewhamilton.androidtime.format.AndroidDateTimeFormatter;
+import dev.drewhamilton.androidtime.format.demo.databinding.DemoBinding;
 
 public class Demo extends AppCompatActivity {
+
+    private DemoBinding binding;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.demo);
+        binding = DemoBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
     }
 
     @Override
@@ -27,16 +30,13 @@ public class Demo extends AppCompatActivity {
     }
 
     private void displayJavaTime() {
-        TextView javaTimeValue = findViewById(R.id.javaTimeValue);
-        DateTimeFormatter formatter = AndroidDateTimeFormatter.ofLocalizedTime(getApplicationContext());
-        javaTimeValue.setText(formatter.format(LocalTime.now()));
+        DateTimeFormatter formatter = AndroidDateTimeFormatter.ofLocalizedTime(this);
+        binding.javaTimeValue.setText(formatter.format(LocalTime.now()));
     }
 
     private void displayThreeTenBpTime() {
-        TextView threeTenBpValue = findViewById(R.id.threeTenBpValue);
         org.threeten.bp.format.DateTimeFormatter formatter =
-                dev.drewhamilton.androidtime.threetenbp.format.AndroidDateTimeFormatter
-                        .ofLocalizedTime(getApplicationContext());
-        threeTenBpValue.setText(formatter.format(org.threeten.bp.LocalTime.now()));
+                dev.drewhamilton.androidtime.threetenbp.format.AndroidDateTimeFormatter.ofLocalizedTime(this);
+        binding.threeTenBpValue.setText(formatter.format(org.threeten.bp.LocalTime.now()));
     }
 }

--- a/app/src/main/res/layout/demo.xml
+++ b/app/src/main/res/layout/demo.xml
@@ -27,12 +27,13 @@
       android:layout_width="wrap_content"
       android:layout_height="wrap_content"
 
-      android:hint="@string/java_time_hint"
       android:textAppearance="@style/TextAppearance.AppCompat.Display1"
 
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintTop_toBottomOf="@+id/javaTimeLabel"
-      app:layout_constraintBottom_toTopOf="@+id/space" />
+      app:layout_constraintBottom_toTopOf="@+id/space"
+
+      tools:text="15:40" />
 
   <Space
       android:id="@+id/space"

--- a/app/src/main/res/layout/demo.xml
+++ b/app/src/main/res/layout/demo.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
 
     android:layout_width="match_parent"
     android:layout_height="match_parent"
 
+    android:gravity="center_vertical"
+    android:orientation="vertical"
     android:padding="16dp">
 
   <TextView
@@ -15,12 +16,7 @@
       android:layout_height="wrap_content"
 
       android:text="@string/java_time"
-      android:textAppearance="@style/TextAppearance.AppCompat.Caption"
-
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toTopOf="parent"
-      app:layout_constraintBottom_toTopOf="@+id/javaTimeValue"
-      app:layout_constraintVertical_chainStyle="packed" />
+      android:textAppearance="@style/TextAppearance.AppCompat.Caption" />
 
   <TextView
       android:id="@+id/javaTimeValue"
@@ -29,20 +25,12 @@
 
       android:textAppearance="@style/TextAppearance.AppCompat.Display1"
 
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/javaTimeLabel"
-      app:layout_constraintBottom_toTopOf="@+id/space"
-
       tools:text="15:40" />
 
   <Space
       android:id="@+id/space"
       android:layout_width="0dp"
-      android:layout_height="48dp"
-
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/javaTimeValue"
-      app:layout_constraintBottom_toTopOf="@+id/threeTenBpLabel" />
+      android:layout_height="48dp" />
 
   <TextView
       android:id="@+id/threeTenBpLabel"
@@ -51,11 +39,7 @@
 
       android:text="@string/three_ten_bp"
       android:textAppearance="@style/TextAppearance.AppCompat.Caption"
-      android:textColor="@color/lightBlue"
-
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/space"
-      app:layout_constraintBottom_toTopOf="@+id/threeTenBpValue" />
+      android:textColor="@color/lightBlue" />
 
   <TextView
       android:id="@+id/threeTenBpValue"
@@ -64,10 +48,6 @@
 
       android:textAppearance="@style/TextAppearance.AppCompat.Display1"
 
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/threeTenBpLabel"
-      app:layout_constraintBottom_toBottomOf="parent"
-
       tools:text="15:40" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/values-v26/strings.xml
+++ b/app/src/main/res/values-v26/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <string name="java_time_hint" />
-</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,4 @@
 
   <string name="java_time">java.time</string>
   <string name="three_ten_bp">ThreeTenBP</string>
-
-  <string name="java_time_hint">Not supported</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,9 @@ ext {
 
     buildToolsVersion = '29.0.3'
     compileSdk = 29
+    multidexMinSdk = 4
     threeTenAbpMinSdk = 15
+    androidXMinSdk = 14
 
     keystore = project.hasProperty('personalKeystore') ? personalKeystore : 'x'
     keystorePassword = project.hasProperty('personalKeystorePassword') ? personalKeystorePassword : 'x'

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ allprojects { project ->
 ext {
     libraryVersion = '2.0.0'
 
+    buildToolsVersion = '29.0.3'
     compileSdk = 29
     threeTenAbpMinSdk = 15
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,8 @@ allprojects { project ->
 ext {
     libraryVersion = '2.0.0'
 
-    minSdkVersion = 15
-    compileSdkVersion = 29
+    compileSdk = 29
+    threeTenAbpMinSdk = 15
 
     keystore = project.hasProperty('personalKeystore') ? personalKeystore : 'x'
     keystorePassword = project.hasProperty('personalKeystorePassword') ? personalKeystorePassword : 'x'

--- a/javatime/build.gradle
+++ b/javatime/build.gradle
@@ -7,10 +7,10 @@ ext {
 }
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.compileSdk
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
+        minSdkVersion rootProject.ext.threeTenAbpMinSdk
         versionName rootProject.ext.libraryVersion
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/javatime/build.gradle
+++ b/javatime/build.gradle
@@ -8,6 +8,7 @@ ext {
 
 android {
     compileSdkVersion rootProject.ext.compileSdk
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.threeTenAbpMinSdk

--- a/javatime/build.gradle
+++ b/javatime/build.gradle
@@ -11,7 +11,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.threeTenAbpMinSdk
+        minSdkVersion rootProject.ext.multidexMinSdk
         versionName rootProject.ext.libraryVersion
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/javatime/src/androidTest/AndroidManifest.xml
+++ b/javatime/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,12 @@
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="dev.drewhamilton.androidtime.format.test">
 
   <uses-permission android:name="android.permission.WRITE_SETTINGS" />
+
+  <!--Allow use of test frameworks with higher minSdk than this library's:-->
+  <uses-sdk tools:overrideLibrary="dev.drewhamilton.androidtime.format.test, androidx.test.ext.junit, androidx.core,
+          androidx.test.core, androidx.test, androidx.lifecycle, androidx.versionedparcelable" />
 
 </manifest>

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -6,7 +6,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.threeTenAbpMinSdk
+        minSdkVersion rootProject.ext.androidXMinSdk
         versionName rootProject.ext.libraryVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.compileSdk
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
+        minSdkVersion rootProject.ext.threeTenAbpMinSdk
         versionName rootProject.ext.libraryVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion rootProject.ext.compileSdk
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.threeTenAbpMinSdk

--- a/threetenbp/build.gradle
+++ b/threetenbp/build.gradle
@@ -8,6 +8,7 @@ ext {
 
 android {
     compileSdkVersion rootProject.ext.compileSdk
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         minSdkVersion rootProject.ext.threeTenAbpMinSdk

--- a/threetenbp/build.gradle
+++ b/threetenbp/build.gradle
@@ -7,10 +7,10 @@ ext {
 }
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.compileSdk
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
+        minSdkVersion rootProject.ext.threeTenAbpMinSdk
         versionName rootProject.ext.libraryVersion
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Multidex minSdk is 4, so the java.time artifact's minSdk is lowered to 4 as well.

Closes #21.