### PR TITLE
Add date-only and date-time formatters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
             multidex: 'com.android.support:multidex:1.0.3',
             threeTenAbp: 'com.jakewharton.threetenabp:threetenabp:1.2.3',
             threeTenBp: 'org.threeten:threetenbp:1.4.3:no-tzdb',
+            truth: 'com.google.truth:truth:1.0.1'
         ]
     }
 

--- a/javatime/api/javatime.api
+++ b/javatime/api/javatime.api
@@ -1,4 +1,8 @@
 public final class dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter {
+	public static fun ofLocalizedDate (Landroid/content/Context;Ljava/time/format/FormatStyle;)Ljava/time/format/DateTimeFormatter;
+	public static fun ofLocalizedDateTime (Landroid/content/Context;Ljava/time/format/FormatStyle;)Ljava/time/format/DateTimeFormatter;
+	public static fun ofLocalizedDateTime (Landroid/content/Context;Ljava/time/format/FormatStyle;Ljava/time/format/FormatStyle;)Ljava/time/format/DateTimeFormatter;
 	public static fun ofLocalizedTime (Landroid/content/Context;)Ljava/time/format/DateTimeFormatter;
+	public static fun ofLocalizedTime (Landroid/content/Context;Ljava/time/format/FormatStyle;)Ljava/time/format/DateTimeFormatter;
 }
 

--- a/javatime/build.gradle
+++ b/javatime/build.gradle
@@ -43,6 +43,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
         coreLibraryDesugaringEnabled true
     }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
+    }
 }
 
 apply from: '../publish.gradle'

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -224,7 +224,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         testLocale = Locale.ITALY
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.MEDIUM)
-        assertEquals("24 apr 2010", formatter.format(DATE))
+        assertEquals(ITALY_MEDIUM_DATE, formatter.format(DATE))
     }
 
     @Test fun ofLocalizedDate_italyLocaleLongFormat_usesLongItalyFormat() {
@@ -349,7 +349,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM)
 
         val result = formatter.format(DATE_TIME)
-        assertThat(result).contains("24 apr 2010")
+        assertThat(result).contains(ITALY_MEDIUM_DATE)
         assertThat(result).contains(ITALY_MEDIUM_TIME)
     }
 
@@ -451,7 +451,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.LONG)
 
         val result = formatter.format(DATE_TIME)
-        assertThat(result).contains("24 apr 2010")
+        assertThat(result).contains(ITALY_MEDIUM_DATE)
         assertThat(result).contains("16:44:00 Z")
     }
 
@@ -487,7 +487,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.SHORT)
 
         val result = formatter.format(DATE_TIME)
-        assertThat(result).contains("24 apr 2010")
+        assertThat(result).contains(ITALY_MEDIUM_DATE)
         assertThat(result).contains("4:44 PM")
     }
 
@@ -499,7 +499,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.SHORT)
 
         val result = formatter.format(DATE_TIME)
-        assertThat(result).contains("24 apr 2010")
+        assertThat(result).contains(ITALY_MEDIUM_DATE)
         assertThat(result).contains("16:44")
     }
     //endregion
@@ -516,9 +516,16 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
         private val LEGACY_TIME: Date = TIME_FORMAT_24_IN_UTC.parse("16:44")!!
 
+        private val ITALY_MEDIUM_DATE = if (Build.VERSION.SDK_INT > 22)
+            "24 apr 2010"
+        else
+            "24/apr/2010"
+
         private val ITALY_MEDIUM_TIME = if (Build.VERSION.SDK_INT > 25)
             "16:44:00"
-        else
+        else if (Build.VERSION.SDK_INT > 22)
             "4:44:00 PM"
+        else
+            "04:44:00 PM"
     }
 }

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -1,6 +1,7 @@
 package dev.drewhamilton.androidtime.format
 
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import com.google.common.truth.Truth.assertThat
 import dev.drewhamilton.androidtime.format.test.TimeSettingTest
@@ -12,6 +13,9 @@ import java.time.LocalTime
 import java.time.Month
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.time.chrono.Chronology
+import java.time.chrono.IsoChronology
+import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
 import java.util.Date
 import java.util.Locale
@@ -19,10 +23,10 @@ import java.util.Locale
 @RequiresApi(21) // Instrumented tests for Dynamic Features is not supported on API < 21 (AGP 4.0.0-beta04)
 class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
-    private val expectedFormattedTime: String
-        get() = androidTimeFormatInUtc.format(LEGACY_TIME)
+    private val expectedShortFormattedTime: String
+        get() = androidShortTimeFormatInUtc.format(LEGACY_TIME)
 
-    //region ofLocalizedTime
+    //region ofLocalizedTime with default style
     @Test fun ofLocalizedTime_nullSystemSettingUsLocale_uses12HourFormat() {
         assumeFalse(
             "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
@@ -34,7 +38,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
         val formattedTime = formatter.format(TIME)
-        assertEquals(expectedFormattedTime, formattedTime)
+        assertEquals(expectedShortFormattedTime, formattedTime)
     }
 
     @Test fun ofLocalizedTime_12SystemSettingUsLocale_uses12HourFormat() {
@@ -43,7 +47,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
         val formattedTime = formatter.format(TIME)
-        assertEquals(expectedFormattedTime, formattedTime)
+        assertEquals(expectedShortFormattedTime, formattedTime)
     }
 
     @Test fun ofLocalizedTime_24SystemSettingUsLocale_uses24HourFormat() {
@@ -52,7 +56,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
         val formattedTime = formatter.format(TIME)
-        assertEquals(expectedFormattedTime, formattedTime)
+        assertEquals(expectedShortFormattedTime, formattedTime)
     }
 
     @Test fun ofLocalizedTime_nullSystemSettingItalyLocale_uses24HourFormat() {
@@ -66,7 +70,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
         val formattedTime = formatter.format(TIME)
-        assertEquals(expectedFormattedTime, formattedTime)
+        assertEquals(expectedShortFormattedTime, formattedTime)
     }
 
     @Test fun ofLocalizedTime_12SystemSettingItalyLocale_uses12HourFormat() {
@@ -75,7 +79,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
         val formattedTime = formatter.format(TIME)
-        assertEquals(expectedFormattedTime, formattedTime)
+        assertEquals(expectedShortFormattedTime, formattedTime)
     }
 
     @Test fun ofLocalizedTime_24SystemSettingItalyLocale_uses24HourFormat() {
@@ -84,7 +88,115 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext)
         val formattedTime = formatter.format(TIME)
-        assertEquals(expectedFormattedTime, formattedTime)
+        assertEquals(expectedShortFormattedTime, formattedTime)
+    }
+    //endregion
+
+    //region ofLocalizedTime with explicit style
+    @Test fun ofLocalizedTime_nullSystemSettingUsLocaleShortFormat_uses12HourFormat() {
+        assumeFalse(
+            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
+            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
+        )
+
+        systemTimeSetting = null
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.SHORT)
+        val formattedTime = formatter.format(TIME)
+        assertEquals(expectedShortFormattedTime, formattedTime)
+    }
+
+    @Test fun ofLocalizedTime_12SystemSettingUsLocaleShortFormat_uses12HourFormat() {
+        systemTimeSetting = TIME_SETTING_12
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.SHORT)
+        val formattedTime = formatter.format(TIME)
+        assertEquals(expectedShortFormattedTime, formattedTime)
+    }
+
+    @Test fun ofLocalizedTime_24SystemSettingUsLocaleShortFormat_uses24HourFormat() {
+        systemTimeSetting = TIME_SETTING_24
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.SHORT)
+        val formattedTime = formatter.format(TIME)
+        assertEquals(expectedShortFormattedTime, formattedTime)
+    }
+
+    @Test fun ofLocalizedTime_usLocaleMediumFormat_usesMediumUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.MEDIUM)
+        assertEquals("4:44:00 PM", formatter.format(TIME))
+    }
+
+    @Test fun ofLocalizedTime_usLocaleLongFormat_usesLongUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.LONG)
+        assertEquals("4:44:00 PM Z", formatter.format(DATE_TIME))
+    }
+
+    @Test fun ofLocalizedTime_usLocaleFullFormat_usesFullUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.FULL)
+        assertEquals("4:44:00 PM Z", formatter.format(DATE_TIME))
+    }
+
+    @Test fun ofLocalizedTime_nullSystemSettingItalyLocaleShortFormat_uses24HourFormat() {
+        assumeFalse(
+            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
+            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
+        )
+
+        systemTimeSetting = null
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.SHORT)
+        val formattedTime = formatter.format(TIME)
+        assertEquals(expectedShortFormattedTime, formattedTime)
+    }
+
+    @Test fun ofLocalizedTime_12SystemSettingItalyLocaleShortFormat_uses12HourFormat() {
+        systemTimeSetting = TIME_SETTING_12
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.SHORT)
+        val formattedTime = formatter.format(TIME)
+        assertEquals(expectedShortFormattedTime, formattedTime)
+    }
+
+    @Test fun ofLocalizedTime_24SystemSettingItalyLocaleShortFormat_uses24HourFormat() {
+        systemTimeSetting = TIME_SETTING_24
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.SHORT)
+        val formattedTime = formatter.format(TIME)
+        assertEquals(expectedShortFormattedTime, formattedTime)
+    }
+
+    @Test fun ofLocalizedTime_italyLocaleMediumFormat_usesMediumItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.MEDIUM)
+        assertEquals(ITALY_MEDIUM_TIME, formatter.format(TIME))
+    }
+
+    @Test fun ofLocalizedTime_italyLocaleLongFormat_usesLongItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.LONG)
+        assertEquals("16:44:00 Z", formatter.format(DATE_TIME))
+    }
+
+    @Test fun ofLocalizedTime_italyLocaleFullFormat_usesFullItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedTime(testContext, FormatStyle.FULL)
+        assertEquals("16:44:00 Z", formatter.format(DATE_TIME))
     }
     //endregion
 

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -524,8 +524,8 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         private val ITALY_MEDIUM_TIME = when {
             Build.VERSION.SDK_INT > 25 -> "16:44:00"
             Build.VERSION.SDK_INT > 22 -> "4:44:00 PM"
-            Build.VERSION.SDK_INT > 21 -> "16:44:00"
-            else -> "04:44:00 PM"
+            Build.VERSION.SDK_INT > 21 -> "04:44:00 PM"
+            else -> "16:44:00"
         }
     }
 }

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -521,11 +521,11 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         else
             "24/apr/2010"
 
-        private val ITALY_MEDIUM_TIME = if (Build.VERSION.SDK_INT > 25)
-            "16:44:00"
-        else if (Build.VERSION.SDK_INT > 22)
-            "4:44:00 PM"
-        else
-            "04:44:00 PM"
+        // This may fail locally on API < 23, but passes on GitHub
+        private val ITALY_MEDIUM_TIME = when {
+            Build.VERSION.SDK_INT > 25 -> "16:44:00"
+            Build.VERSION.SDK_INT > 22 -> "4:44:00 PM"
+            else -> "16:44:00"
+        }
     }
 }

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -1,7 +1,6 @@
 package dev.drewhamilton.androidtime.format
 
 import android.os.Build
-import android.util.Log
 import androidx.annotation.RequiresApi
 import com.google.common.truth.Truth.assertThat
 import dev.drewhamilton.androidtime.format.test.TimeSettingTest
@@ -13,9 +12,6 @@ import java.time.LocalTime
 import java.time.Month
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
-import java.time.chrono.Chronology
-import java.time.chrono.IsoChronology
-import java.time.format.DateTimeFormatterBuilder
 import java.time.format.FormatStyle
 import java.util.Date
 import java.util.Locale
@@ -28,10 +24,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
     //region ofLocalizedTime with default style
     @Test fun ofLocalizedTime_nullSystemSettingUsLocale_uses12HourFormat() {
-        assumeFalse(
-            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
-            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
-        )
+        assumeNullableSystemTimeSetting()
 
         systemTimeSetting = null
         testLocale = Locale.US
@@ -60,10 +53,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_nullSystemSettingItalyLocale_uses24HourFormat() {
-        assumeFalse(
-            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
-            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
-        )
+        assumeNullableSystemTimeSetting()
 
         systemTimeSetting = null
         testLocale = Locale.ITALY
@@ -94,10 +84,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
     //region ofLocalizedTime with explicit style
     @Test fun ofLocalizedTime_nullSystemSettingUsLocaleShortFormat_uses12HourFormat() {
-        assumeFalse(
-            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
-            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
-        )
+        assumeNullableSystemTimeSetting()
 
         systemTimeSetting = null
         testLocale = Locale.US
@@ -147,10 +134,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
 
     @Test fun ofLocalizedTime_nullSystemSettingItalyLocaleShortFormat_uses24HourFormat() {
-        assumeFalse(
-            "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
-            Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
-        )
+        assumeNullableSystemTimeSetting()
 
         systemTimeSetting = null
         testLocale = Locale.ITALY
@@ -259,7 +243,10 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     //endregion
 
     //region ofLocalizedDateTime with dateTimeStyle
-    @Test fun ofLocalizedDateTime_usLocaleShortDateTimeFormat_usesShortUsFormat() {
+    @Test fun ofLocalizedDateTime_nullSystemSettingUsLocaleShortDateTimeFormat_usesShort12HourUsFormat() {
+        assumeNullableSystemTimeSetting()
+
+        systemTimeSetting = null
         testLocale = Locale.US
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT)
@@ -267,6 +254,28 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         val result = formatter.format(DATE_TIME)
         assertThat(result).contains("4/24/10")
         assertThat(result).contains("4:44 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_12SystemSettingUsLocaleShortDateTimeFormat_usesShort12HourUsFormat() {
+        systemTimeSetting = TIME_SETTING_12
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("4/24/10")
+        assertThat(result).contains("4:44 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_24SystemSettingUsLocaleShortDateTimeFormat_usesShort24HourUsFormat() {
+        systemTimeSetting = TIME_SETTING_24
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("4/24/10")
+        assertThat(result).contains("16:44")
     }
 
     @Test fun ofLocalizedDateTime_usLocaleMediumDateTimeFormat_usesMediumUsFormat() {
@@ -299,15 +308,39 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         assertThat(result).contains("4:44:00 PM Z")
     }
 
-    @Test fun ofLocalizedDateTime_italyLocaleShortDateTimeFormat_usesShortItalyFormat() {
+    @Test fun ofLocalizedDateTime_nullSystemSettingItalyLocaleShortDateTimeFormat_usesShort24HourItalyFormat() {
+        assumeNullableSystemTimeSetting()
+
+        systemTimeSetting = null
         testLocale = Locale.ITALY
-        systemTimeSetting = TIME_SETTING_24
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT)
 
         val result = formatter.format(DATE_TIME)
         assertThat(result).contains("24/04/10")
-        assertThat(result).contains(ITALY_SHORT_TIME)
+        assertThat(result).contains("16:44")
+    }
+
+    @Test fun ofLocalizedDateTime_12SystemSettingItalyLocaleShortDateTimeFormat_usesShort12HourItalyFormat() {
+        systemTimeSetting = TIME_SETTING_12
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24/04/10")
+        assertThat(result).contains("4:44 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_24SystemSettingItalyLocaleShortDateTimeFormat_usesShort24HourItalyFormat() {
+        systemTimeSetting = TIME_SETTING_24
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24/04/10")
+        assertThat(result).contains("16:44")
     }
 
     @Test fun ofLocalizedDateTime_italyLocaleMediumDateTimeFormat_usesMediumItalyFormat() {
@@ -417,6 +450,11 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         assertThat(result).contains(ITALY_SHORT_TIME)
     }
     //endregion
+
+    private fun assumeNullableSystemTimeSetting() = assumeFalse(
+        "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
+        Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
+    )
 
     private companion object {
         private val DATE = LocalDate.of(2010, Month.APRIL, 24)

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -379,7 +379,21 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         assertThat(result).contains("4:44:00 PM Z")
     }
 
-    @Test fun ofLocalizedDateTime_usLocaleMediumDateFormatShortTimeFormat_usesMediumDateShortTimeUsFormat() {
+    @Test fun ofLocalizedDateTime_nullSettingUsLocaleLongDateFormatShortTimeFormat_usesLongDate12HourTimeUsFormat() {
+        assumeNullableSystemTimeSetting()
+
+        systemTimeSetting = null
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.LONG, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("April 24, 2010")
+        assertThat(result).contains("4:44 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_12SettingUsLocaleMediumDateFormatShortTimeFormat_usesMediumDate12HourTimeUsFormat() {
+        systemTimeSetting = TIME_SETTING_12
         testLocale = Locale.US
 
         val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.SHORT)
@@ -387,6 +401,17 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         val result = formatter.format(DATE_TIME)
         assertThat(result).contains("Apr 24, 2010")
         assertThat(result).contains("4:44 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_24SettingUsLocaleMediumDateFormatShortTimeFormat_usesMediumDate24HourTimeUsFormat() {
+        systemTimeSetting = TIME_SETTING_24
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("Apr 24, 2010")
+        assertThat(result).contains("16:44")
     }
 
     @Test fun ofLocalizedDateTime_usLocaleLongDateFormatFullTimeFormat_usesLongDateFullTimeUsFormat() {
@@ -440,14 +465,42 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         assertThat(result).contains(ITALY_MEDIUM_TIME)
     }
 
-    @Test fun ofLocalizedDateTime_italyLocaleFullDateFormatShortTimeFormat_usesFullDateShortTimeItalyFormat() {
+    @Test
+    fun ofLocalizedDateTime_nullSettingItalyLocaleLongDateFormatShortTimeFormat_usesLongDate24HourTimeItalyFormat() {
+        assumeNullableSystemTimeSetting()
+
+        systemTimeSetting = null
         testLocale = Locale.ITALY
 
-        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.FULL, FormatStyle.SHORT)
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.LONG, FormatStyle.SHORT)
 
         val result = formatter.format(DATE_TIME)
-        assertThat(result).contains("sabato 24 aprile 2010")
-        assertThat(result).contains(ITALY_SHORT_TIME)
+        assertThat(result).contains("24 aprile 2010")
+        assertThat(result).contains("16:44")
+    }
+
+    @Test
+    fun ofLocalizedDateTime_12SettingItalyLocaleMediumDateFormatShortTimeFormat_usesMediumDate12HourTimeItalyFormat() {
+        systemTimeSetting = TIME_SETTING_12
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24 apr 2010")
+        assertThat(result).contains("4:44 PM")
+    }
+
+    @Test
+    fun ofLocalizedDateTime_24SettingItalyLocaleMediumDateFormatShortTimeFormat_usesMediumDate24HourTimeItalyFormat() {
+        systemTimeSetting = TIME_SETTING_24
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24 apr 2010")
+        assertThat(result).contains("16:44")
     }
     //endregion
 
@@ -467,6 +520,5 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
             "16:44:00"
         else
             "4:44:00 PM"
-        private val ITALY_SHORT_TIME = ITALY_MEDIUM_TIME.replace(":00", "")
     }
 }

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -2,6 +2,7 @@ package dev.drewhamilton.androidtime.format
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.google.common.truth.Truth.assertThat
 import dev.drewhamilton.androidtime.format.test.TimeSettingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assume.assumeFalse
@@ -9,6 +10,8 @@ import org.junit.Test
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.Month
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.time.format.FormatStyle
 import java.util.Date
 import java.util.Locale
@@ -143,9 +146,177 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
     //endregion
 
+    //region ofLocalizedDateTime with dateTimeStyle
+    @Test fun ofLocalizedDateTime_usLocaleShortDateTimeFormat_usesShortUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("4/24/10")
+        assertThat(result).contains("4:44 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_usLocaleMediumDateTimeFormat_usesMediumUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("Apr 24, 2010")
+        assertThat(result).contains("4:44:00 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_usLocaleLongDateTimeFormat_usesLongUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.LONG)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("April 24, 2010")
+        assertThat(result).contains("4:44:00 PM Z")
+    }
+
+    @Test fun ofLocalizedDateTime_usLocaleFullDateTimeFormat_usesFullUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.FULL)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("Saturday, April 24, 2010")
+        assertThat(result).contains("4:44:00 PM Z")
+    }
+
+    @Test fun ofLocalizedDateTime_italyLocaleShortDateTimeFormat_usesShortItalyFormat() {
+        testLocale = Locale.ITALY
+        systemTimeSetting = TIME_SETTING_24
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24/04/10")
+        assertThat(result).contains(ITALY_SHORT_TIME)
+    }
+
+    @Test fun ofLocalizedDateTime_italyLocaleMediumDateTimeFormat_usesMediumItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24 apr 2010")
+        assertThat(result).contains(ITALY_MEDIUM_TIME)
+    }
+
+    @Test fun ofLocalizedDateTime_italyLocaleLongDateTimeFormat_usesLongItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.LONG)
+        assertEquals("24 aprile 2010 16:44:00 Z", formatter.format(DATE_TIME))
+    }
+
+    @Test fun ofLocalizedDateTime_italyLocaleFullDateTimeFormat_usesFullItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.FULL)
+        assertEquals("sabato 24 aprile 2010 16:44:00 Z", formatter.format(DATE_TIME))
+    }
+    //endregion
+
+    //region ofLocalizedDateTime with dateStyle and timeStyle
+    @Test fun ofLocalizedDateTime_usLocaleShortDateFormatLongTimeFormat_usesShortDateLongTimeUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT, FormatStyle.LONG)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("4/24/10")
+        assertThat(result).contains("4:44:00 PM Z")
+    }
+
+    @Test fun ofLocalizedDateTime_usLocaleMediumDateFormatShortTimeFormat_usesMediumDateShortTimeUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("Apr 24, 2010")
+        assertThat(result).contains("4:44 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_usLocaleLongDateFormatFullTimeFormat_usesLongDateFullTimeUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.LONG, FormatStyle.FULL)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("April 24, 2010")
+        assertThat(result).contains("4:44:00 PM Z")
+    }
+
+    @Test fun ofLocalizedDateTime_usLocaleFullDateFormatMediumTimeFormat_usesFullDateMediumTimeUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.FULL, FormatStyle.MEDIUM)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("Saturday, April 24, 2010")
+        assertThat(result).contains("4:44:00 PM")
+    }
+
+    @Test fun ofLocalizedDateTime_italyLocaleShortDateFormatFullTimeFormat_usesShortDateFullTimeItalyFormat() {
+        testLocale = Locale.ITALY
+        systemTimeSetting = TIME_SETTING_24
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.SHORT, FormatStyle.FULL)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24/04/10")
+        assertThat(result).contains("16:44:00 Z")
+    }
+
+    @Test fun ofLocalizedDateTime_italyLocaleMediumDateFormatLongTimeFormat_usesMediumDateLongTimeItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.MEDIUM, FormatStyle.LONG)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24 apr 2010")
+        assertThat(result).contains("16:44:00 Z")
+    }
+
+    @Test fun ofLocalizedDateTime_italyLocaleLongDateFormatMediumTimeFormat_usesLongDateMediumTimeItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.LONG, FormatStyle.MEDIUM)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("24 aprile 2010")
+        assertThat(result).contains(ITALY_MEDIUM_TIME)
+    }
+
+    @Test fun ofLocalizedDateTime_italyLocaleFullDateFormatShortTimeFormat_usesFullDateShortTimeItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDateTime(testContext, FormatStyle.FULL, FormatStyle.SHORT)
+
+        val result = formatter.format(DATE_TIME)
+        assertThat(result).contains("sabato 24 aprile 2010")
+        assertThat(result).contains(ITALY_SHORT_TIME)
+    }
+    //endregion
+
     private companion object {
         private val DATE = LocalDate.of(2010, Month.APRIL, 24)
         private val TIME = LocalTime.of(16, 44)
+        private val DATE_TIME = ZonedDateTime.of(DATE, TIME, ZoneOffset.UTC)
+
         private val LEGACY_TIME: Date = TIME_FORMAT_24_IN_UTC.parse("16:44")!!
+
+        private val ITALY_MEDIUM_TIME = if (Build.VERSION.SDK_INT > 25)
+            "16:44:00"
+        else
+            "4:44:00 PM"
+        private val ITALY_SHORT_TIME = ITALY_MEDIUM_TIME.replace(":00", "")
     }
 }

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -521,11 +521,11 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         else
             "24/apr/2010"
 
-        // This may fail locally on API < 23, but passes on GitHub
         private val ITALY_MEDIUM_TIME = when {
             Build.VERSION.SDK_INT > 25 -> "16:44:00"
             Build.VERSION.SDK_INT > 22 -> "4:44:00 PM"
-            else -> "16:44:00"
+            Build.VERSION.SDK_INT > 21 -> "16:44:00"
+            else -> "04:44:00 PM"
         }
     }
 }

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -6,7 +6,10 @@ import dev.drewhamilton.androidtime.format.test.TimeSettingTest
 import org.junit.Assert.assertEquals
 import org.junit.Assume.assumeFalse
 import org.junit.Test
+import java.time.LocalDate
 import java.time.LocalTime
+import java.time.Month
+import java.time.format.FormatStyle
 import java.util.Date
 import java.util.Locale
 
@@ -16,6 +19,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     private val expectedFormattedTime: String
         get() = androidTimeFormatInUtc.format(LEGACY_TIME)
 
+    //region ofLocalizedTime
     @Test fun ofLocalizedTime_nullSystemSettingUsLocale_uses12HourFormat() {
         assumeFalse(
             "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
@@ -79,8 +83,68 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
         val formattedTime = formatter.format(TIME)
         assertEquals(expectedFormattedTime, formattedTime)
     }
+    //endregion
+
+    //region ofLocalizedDate
+    @Test fun ofLocalizedDate_usLocaleShortFormat_usesShortUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.SHORT)
+        assertEquals("4/24/10", formatter.format(DATE))
+    }
+
+    @Test fun ofLocalizedDate_usLocaleMediumFormat_usesMediumUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.MEDIUM)
+        assertEquals("Apr 24, 2010", formatter.format(DATE))
+    }
+
+    @Test fun ofLocalizedDate_usLocaleLongFormat_usesLongUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.LONG)
+        assertEquals("April 24, 2010", formatter.format(DATE))
+    }
+
+    @Test fun ofLocalizedDate_usLocaleFullFormat_usesFullUsFormat() {
+        testLocale = Locale.US
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.FULL)
+        assertEquals("Saturday, April 24, 2010", formatter.format(DATE))
+    }
+
+    @Test fun ofLocalizedDate_italyLocaleShortFormat_usesShortItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.SHORT)
+        assertEquals("24/04/10", formatter.format(DATE))
+    }
+
+    @Test fun ofLocalizedDate_italyLocaleMediumFormat_usesMediumItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.MEDIUM)
+        assertEquals("24 apr 2010", formatter.format(DATE))
+    }
+
+    @Test fun ofLocalizedDate_italyLocaleLongFormat_usesLongItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.LONG)
+        assertEquals("24 aprile 2010", formatter.format(DATE))
+    }
+
+    @Test fun ofLocalizedDate_italyLocaleFullFormat_usesFullItalyFormat() {
+        testLocale = Locale.ITALY
+
+        val formatter = AndroidDateTimeFormatter.ofLocalizedDate(testContext, FormatStyle.FULL)
+        assertEquals("sabato 24 aprile 2010", formatter.format(DATE))
+    }
+    //endregion
 
     private companion object {
+        private val DATE = LocalDate.of(2010, Month.APRIL, 24)
         private val TIME = LocalTime.of(16, 44)
         private val LEGACY_TIME: Date = TIME_FORMAT_24_IN_UTC.parse("16:44")!!
     }

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -39,7 +39,7 @@ public final class AndroidDateTimeFormatter {
     }
 
     /**
-     * Returns a {@link DateTimeFormatter} that can format the time according to the context's locale. If {@param
+     * Returns a {@link DateTimeFormatter} that can format the time according to the context's locale. If {@code
      * timeStyle} is {@link FormatStyle#SHORT}, the formatter also respects the user's 12-/24-hour clock preference.
      * <p>
      * The {@link FormatStyle#FULL} and {@link FormatStyle#LONG} styles typically require a time-zone. When formatting

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -11,6 +11,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.FormatStyle;
 import java.util.Locale;
 
 /**
@@ -23,8 +24,8 @@ public final class AndroidDateTimeFormatter {
      * Returns a {@link DateTimeFormatter} that can format the time according to the context's locale and the user's
      * 12-/24-hour clock preference.
      *
-     * @param context the application context
-     * @return a {@link DateTimeFormatter} that properly formats the time.
+     * @param context The context with which the 12-/24-hour preference and the primary Locale are determined.
+     * @return A {@link DateTimeFormatter} that properly formats the time.
      */
     @NonNull
     public static DateTimeFormatter ofLocalizedTime(@NonNull Context context) {
@@ -43,6 +44,21 @@ public final class AndroidDateTimeFormatter {
                     SimpleDateFormat.class.getName(), legacyFormat.getClass().getName());
             throw new IllegalStateException(errorMessage);
         }
+    }
+
+    public static DateTimeFormatter ofLocalizedDate(Context context, FormatStyle dateStyle) {
+        return DateTimeFormatter.ofLocalizedDate(dateStyle)
+                .withLocale(extractLocale(context));
+    }
+
+    public static DateTimeFormatter ofLocalizedDateTime(Context context, FormatStyle dateTimeStyle) {
+        return DateTimeFormatter.ofLocalizedDateTime(dateTimeStyle)
+                .withLocale(extractLocale(context));
+    }
+
+    public static DateTimeFormatter ofLocalizedDateTime(Context context, FormatStyle dateStyle, FormatStyle timeStyle) {
+        return DateTimeFormatter.ofLocalizedDateTime(dateStyle, timeStyle)
+                .withLocale(extractLocale(context));
     }
 
     @NonNull

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -22,10 +22,11 @@ public final class AndroidDateTimeFormatter {
 
     /**
      * Returns a {@link DateTimeFormatter} that can format the time according to the context's locale and the user's
-     * 12-/24-hour clock preference.
+     * 12-/24-hour clock preference. Due to the implementation of {@link android.text.format.DateFormat#getTimeFormat},
+     * this will always return a {@link FormatStyle#SHORT} time format.
      *
-     * @param context The context with which the 12-/24-hour preference and the primary Locale are determined.
-     * @return A {@link DateTimeFormatter} that properly formats the time.
+     * @param context the context with which the 12-/24-hour preference and the primary locale are determined.
+     * @return a {@link DateTimeFormatter} that properly formats the time.
      */
     @NonNull
     public static DateTimeFormatter ofLocalizedTime(@NonNull Context context) {
@@ -35,34 +36,95 @@ public final class AndroidDateTimeFormatter {
             String pattern = ((SimpleDateFormat) legacyFormat).toPattern();
             return new DateTimeFormatterBuilder()
                     .appendPattern(pattern)
-                    .toFormatter(extractLocale(context));
+                    .toFormatter(extractPrimaryLocale(context));
         } else {
             // DateFormat.getTimeFormat is hard-coded to be a SimpleDateFormat instance, so this should never happen:
-            String errorMessage = String.format(
-                    Locale.US,
+            String errorMessage = String.format(Locale.US,
                     "Expected Android time format to be %s, but it was %s",
                     SimpleDateFormat.class.getName(), legacyFormat.getClass().getName());
             throw new IllegalStateException(errorMessage);
         }
     }
 
-    public static DateTimeFormatter ofLocalizedDate(Context context, FormatStyle dateStyle) {
+    /**
+     * Returns a locale specific date format for the ISO chronology.
+     * <p>
+     * This returns a formatter that will format or parse a date. The exact format pattern used varies by locale.
+     * <p>
+     * The locale is determined from the formatter. The formatter returned directly by this method will use the provided
+     * Context's primary locale.
+     * <p>
+     * Note that the localized pattern is looked up lazily. This {@code DateTimeFormatter} holds the style required and
+     * the locale, looking up the pattern required on demand.
+     * <p>
+     * The returned formatter has a chronology of ISO set to ensure dates in other calendar systems are correctly
+     * converted. It has no override zone and uses the {@link java.time.format.ResolverStyle#SMART SMART} resolver
+     * style.
+     *
+     * @param context the context with which the primary locale is determined.
+     * @param dateStyle the formatter style to obtain
+     * @return the date formatter
+     */
+    @NonNull
+    public static DateTimeFormatter ofLocalizedDate(@NonNull Context context, @NonNull FormatStyle dateStyle) {
         return DateTimeFormatter.ofLocalizedDate(dateStyle)
-                .withLocale(extractLocale(context));
+                .withLocale(extractPrimaryLocale(context));
     }
 
-    public static DateTimeFormatter ofLocalizedDateTime(Context context, FormatStyle dateTimeStyle) {
+    /**
+     * Returns a locale specific date-time formatter for the ISO chronology.
+     * <p>
+     * This returns a formatter that will format or parse a date-time. The exact format pattern used varies by locale.
+     * <p>
+     * The locale is determined from the formatter. The formatter returned directly by this method will use the provided
+     * Context's primary locale.
+     * <p>
+     * Note that the localized pattern is looked up lazily. This {@code DateTimeFormatter} holds the style required and
+     * the locale, looking up the pattern required on demand.
+     * <p>
+     * The returned formatter has a chronology of ISO set to ensure dates in other calendar systems are correctly
+     * converted. It has no override zone and uses the {@link java.time.format.ResolverStyle#SMART SMART} resolver
+     * style.
+     *
+     * @param context the context with which the primary locale is determined
+     * @param dateTimeStyle the formatter style to obtain
+     * @return the date-time formatter
+     */
+    @NonNull
+    public static DateTimeFormatter ofLocalizedDateTime(@NonNull Context context, @NonNull FormatStyle dateTimeStyle) {
         return DateTimeFormatter.ofLocalizedDateTime(dateTimeStyle)
-                .withLocale(extractLocale(context));
+                .withLocale(extractPrimaryLocale(context));
     }
 
-    public static DateTimeFormatter ofLocalizedDateTime(Context context, FormatStyle dateStyle, FormatStyle timeStyle) {
+    /**
+     * Returns a locale specific date and time format for the ISO chronology.
+     * <p>
+     * This returns a formatter that will format or parse a date-time. The exact format pattern used varies by locale.
+     * <p>
+     * The locale is determined from the formatter. The formatter returned directly by this method will use the provided
+     * context's primary locale.
+     * <p>
+     * Note that the localized pattern is looked up lazily. This {@code DateTimeFormatter} holds the style required and
+     * the locale, looking up the pattern required on demand.
+     * <p>
+     * The returned formatter has a chronology of ISO set to ensure dates in other calendar systems are correctly
+     * converted. It has no override zone and uses the {@link java.time.format.ResolverStyle#SMART SMART} resolver
+     * style.
+     *
+     * @param context the context with which the primary locale is determined
+     * @param dateStyle the date formatter style to obtain
+     * @param timeStyle the time formatter style to obtain
+     * @return the date, time or date-time formatter
+     */
+    @NonNull
+    public static DateTimeFormatter ofLocalizedDateTime(@NonNull Context context,
+            @NonNull FormatStyle dateStyle, @NonNull FormatStyle timeStyle) {
         return DateTimeFormatter.ofLocalizedDateTime(dateStyle, timeStyle)
-                .withLocale(extractLocale(context));
+                .withLocale(extractPrimaryLocale(context));
     }
 
     @NonNull
-    private static Locale extractLocale(@NonNull Context context) {
+    private static Locale extractPrimaryLocale(@NonNull Context context) {
         Configuration configuration = context.getResources().getConfiguration();
         Locale locale = null;
         if (Build.VERSION.SDK_INT >= 24) {

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -24,6 +24,7 @@ android {
 dependencies {
     api deps.junitAndroid
     api deps.androidTestRules
+    api deps.truth
 
     implementation deps.kotlinStdLib
     implementation 'androidx.core:core:1.2.0'

--- a/test/src/main/java/dev/drewhamilton/androidtime/format/test/TimeSettingTest.kt
+++ b/test/src/main/java/dev/drewhamilton/androidtime/format/test/TimeSettingTest.kt
@@ -40,7 +40,7 @@ abstract class TimeSettingTest {
     protected var testLocale: Locale
         get() = ConfigurationCompat.getLocales(testContext.resources.configuration)[0]
         set(value) {
-            setLocales(LocaleListCompat.create(value))
+            testContext.setLocales(LocaleListCompat.create(value))
         }
 
     protected var systemTimeSetting: String?
@@ -58,17 +58,17 @@ abstract class TimeSettingTest {
     }
 
     @After fun restoreLocales() {
-        setLocales(originalLocales)
+        testContext.setLocales(originalLocales)
     }
 
-    private fun setLocales(locales: LocaleListCompat) = when {
+    private fun Context.setLocales(locales: LocaleListCompat) = when {
         Build.VERSION.SDK_INT >= 24 ->
-            testContext.resources.configuration.setLocales(locales.unwrap() as LocaleList)
+            resources.configuration.setLocales(locales.unwrap() as LocaleList)
         Build.VERSION.SDK_INT >= 17 ->
-            testContext.resources.configuration.setLocale(locales[0])
+            resources.configuration.setLocale(locales[0])
         else ->
             @Suppress("DEPRECATION")
-            testContext.resources.configuration.locale = locales[0]
+            resources.configuration.locale = locales[0]
     }
 
     @Before fun cacheOriginalTimeSetting() {

--- a/test/src/main/java/dev/drewhamilton/androidtime/format/test/TimeSettingTest.kt
+++ b/test/src/main/java/dev/drewhamilton/androidtime/format/test/TimeSettingTest.kt
@@ -32,7 +32,7 @@ abstract class TimeSettingTest {
     protected val testContext: Context
         get() = InstrumentationRegistry.getInstrumentation().context
 
-    protected val androidTimeFormatInUtc: DateFormat
+    protected val androidShortTimeFormatInUtc: DateFormat
         get() = android.text.format.DateFormat.getTimeFormat(testContext).apply {
             timeZone = TimeZone.getTimeZone("UTC")
         }

--- a/test/src/main/java/dev/drewhamilton/androidtime/format/test/TimeSettingTest.kt
+++ b/test/src/main/java/dev/drewhamilton/androidtime/format/test/TimeSettingTest.kt
@@ -76,27 +76,54 @@ abstract class TimeSettingTest {
         try {
             forceRestoreSystemTimeSetting()
             canResetSystemTimeSetting = true
-            Log.d(TAG, "Cached original setting: $originalTimeSetting")
+            Log.d(TAG, "Cached original device time setting: $originalTimeSetting")
         } catch (illegalArgumentException: IllegalArgumentException) {
             canResetSystemTimeSetting = false
-            Log.w(TAG, "Cannot restore original time setting; will fall back to setting from primary Locale")
+            Log.w(TAG, "Cannot restore original device time setting; will fall back to setting from primary Locale")
         }
     }
 
     @After fun restoreTimeSetting() {
         if (canResetSystemTimeSetting) {
             forceRestoreSystemTimeSetting()
-            Log.d(TAG, "Reset original setting: $originalTimeSetting")
+            Log.d(TAG, "Reset device time setting to original setting: $originalTimeSetting")
         } else {
-            val originalLocale = originalLocales[0]
-            val timeFormat = DateFormat.getTimeInstance(DateFormat.SHORT, originalLocale)
-            val formattedTime = timeFormat.format(TEN_PM)
-            systemTimeSetting = if (formattedTime.contains("22")) TIME_SETTING_24 else TIME_SETTING_12
+            val newTimeSetting = if (originalLocales[0].is24HourLocale())
+                TIME_SETTING_24
+            else
+                TIME_SETTING_12
+            systemTimeSetting = newTimeSetting
+            Log.d(TAG, "Reset device time setting to: $newTimeSetting")
         }
     }
 
     private fun forceRestoreSystemTimeSetting() {
         systemTimeSetting = originalTimeSetting
+    }
+
+    private fun Locale.is24HourLocale(): Boolean {
+        val natural = DateFormat.getTimeInstance(DateFormat.LONG, this)
+        return if (natural is SimpleDateFormat)
+            natural.toPattern().hasDesignator('H')
+        else
+            false
+    }
+
+    private fun CharSequence?.hasDesignator(designator: Char): Boolean {
+        if (this == null)
+            return false
+
+        var insideQuote = false
+        forEach { c ->
+            if (c == '\'') {
+                insideQuote = !insideQuote
+            } else if (!insideQuote) {
+                if (c == designator)
+                    return true
+            }
+        }
+
+        return false
     }
 
     protected companion object {
@@ -112,7 +139,5 @@ abstract class TimeSettingTest {
                 timeZone = TimeZone.getTimeZone("UTC")
             }
         }
-
-        private val TEN_PM = TIME_FORMAT_24_IN_UTC.parse("22:00")
     }
 }

--- a/threetenbp/src/androidTest/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatterTest.kt
+++ b/threetenbp/src/androidTest/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatterTest.kt
@@ -12,7 +12,7 @@ import java.util.Locale
 class AndroidDateTimeFormatterTest : TimeSettingTest() {
 
     private val expectedFormattedTime: String
-        get() = androidTimeFormatInUtc.format(LEGACY_TIME)
+        get() = androidShortTimeFormatInUtc.format(LEGACY_TIME)
 
     @Test fun ofLocalizedTime_nullSystemSettingUsLocale_uses12HourFormat() {
         assumeFalse(


### PR DESCRIPTION
All formatters use the given Context's primary Locale.

Date-time formatters with a SHORT overall style or a SHORT time style substitute Android's short time pattern, so the 12/24 setting is always respected for SHORT times.

Additionally, an overload for `ofLocalizedTime` is added for different styles. MEDIUM, LONG, and FULL do not respect the 12/24 setting.

Closes #17.