### PR TITLE
Publish Gradle module metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Add additional factory methods for time, date, and date-time formatters. Time an
 formatters created with the "short" time style will use the system 12-/24-hour time setting to
 format times.
 
-In the rare case that a short time pattern respecting the system 12-/24-hour time
-setting can not be found, a fallback based on the Context's locale will be used instead.
+In the rare case that a short time pattern respecting the system 12-/24-hour time setting can not be
+found, a fallback based on the Context's locale will be used instead.
 
 ## 2.0.1
 _2020-04-13_

--- a/publish.gradle
+++ b/publish.gradle
@@ -3,7 +3,6 @@
 
 group = 'dev.drewhamilton.androidtime'
 version = rootProject.ext.libraryVersion
-def projectName = name
 
 task sourcesJar(type: Jar) {
     archiveClassifier.set 'sources'
@@ -29,87 +28,65 @@ artifacts {
 }
 
 apply plugin: 'maven-publish'
-publishing {
-    publications {
-        release(MavenPublication) {
-            groupId group
-            artifactId artifactName
-            version version
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                groupId group
+                artifactId artifactName
+                version version
 
-            artifact artifact("$buildDir/outputs/aar/$projectName-release.aar")
-            artifact sourcesJar
-            artifact javadocJar
+                from components.release
+                artifact sourcesJar
+                artifact javadocJar
 
-            pom {
-                name = artifactName
-                description = publishedDescription
+                pom {
+                    name = artifactName
+                    description = publishedDescription
 
-                url = 'https://github.com/drewhamilton/AndroidDateTimeFormatters'
-                licenses {
-                    license {
-                        name = 'The Apache Software License, Version 2.0'
-                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-                    }
-                }
-
-                developers {
-                    developer {
-                        id = 'drewhamilton'
-                        name = 'Drew Hamilton'
-                        email = 'drew.hamilton.0+android@gmail.com'
-                    }
-                }
-
-                scm {
-                    connection = 'scm:git:github.com/drewhamilton/AndroidDateTimeFormatters.git'
-                    developerConnection = 'scm:git:ssh://github.com/drewhamilton/AndroidDateTimeFormatters.git'
                     url = 'https://github.com/drewhamilton/AndroidDateTimeFormatters'
-                }
-
-                // TODO WORKAROUND: Figure out why OkHttp doesn't have to write this block
-                withXml {
-                    def dependenciesNode = asNode().appendNode('dependencies')
-
-                    def addDependency = { Dependency dep, String scope ->
-                        if (!isValid(dep)) return
-
-                        logger.info "$name dependency: $dep"
-
-                        final dependencyNode = dependenciesNode.appendNode('dependency')
-                            .appendNode('groupId', dep.group).parent()
-                            .appendNode('artifactId', extractDependencyArtifactId(dep)).parent()
-                            .appendNode('version', dep.version).parent()
-                            .appendNode('scope', scope).parent()
-
-                        if (isLocalDependency(dep))
-                            dependencyNode.appendNode('type', 'aar').parent()
+                    licenses {
+                        license {
+                            name = 'The Apache Software License, Version 2.0'
+                            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        }
                     }
 
-                    configurations.api.getDependencies().each { dep -> addDependency(dep, 'compile') }
-                    configurations.implementation.getDependencies().each { dep -> addDependency(dep, 'runtime') }
-                    configurations.compile.getDependencies().each { dep -> addDependency(dep, 'compile') }
+                    developers {
+                        developer {
+                            id = 'drewhamilton'
+                            name = 'Drew Hamilton'
+                            email = 'drew.hamilton.0+android@gmail.com'
+                        }
+                    }
+
+                    scm {
+                        connection = 'scm:git:github.com/drewhamilton/AndroidDateTimeFormatters.git'
+                        developerConnection = 'scm:git:ssh://github.com/drewhamilton/AndroidDateTimeFormatters.git'
+                        url = 'https://github.com/drewhamilton/AndroidDateTimeFormatters'
+                    }
                 }
             }
         }
-    }
 
-    repositories {
-        maven {
-            name = 'MavenCentral'
+        repositories {
+            maven {
+                name = 'MavenCentral'
 
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
 
-            def sonatypeIssuesUsername = project.hasProperty('personalSonatypeIssuesUsername')
-                ? personalSonatypeIssuesUsername
-                : 'x'
-            def sonatypeIssuesPassword = project.hasProperty('personalSonatypeIssuesPassword')
-                ? personalSonatypeIssuesPassword
-                : 'x'
-            credentials {
-                username sonatypeIssuesUsername
-                password sonatypeIssuesPassword
+                def sonatypeIssuesUsername = project.hasProperty('personalSonatypeIssuesUsername')
+                    ? personalSonatypeIssuesUsername
+                    : 'x'
+                def sonatypeIssuesPassword = project.hasProperty('personalSonatypeIssuesPassword')
+                    ? personalSonatypeIssuesPassword
+                    : 'x'
+                credentials {
+                    username sonatypeIssuesUsername
+                    password sonatypeIssuesPassword
+                }
             }
         }
     }
@@ -121,28 +98,4 @@ ext.'signing.password' = hasProperty('personalGpgPassword') ? personalGpgPasswor
 ext.'signing.secretKeyRingFile' = hasProperty('personalGpgKeyringFile') ? personalGpgKeyringFile : 'x'
 signing {
     sign publishing.publications
-}
-
-private static boolean isValid(Dependency dep) {
-    String artifactId = extractDependencyArtifactId(dep)
-    String version = dep.version
-    return dep.group != null &&
-        version != null && version != 'unspecified' &&
-        artifactId != null && artifactId != 'unspecified'
-}
-
-private static String extractDependencyArtifactId(dependency) {
-    def depArtifactId = dependency.name
-
-    // If ext.artifactName is explicitly defined, use that over the module name:
-    if (isLocalDependency(dependency)) {
-        def depProject = dependency.dependencyProject
-        if (depProject.hasProperty('artifactName'))
-            depArtifactId = depProject.artifactName
-    }
-    return depArtifactId
-}
-
-private static boolean isLocalDependency(dependency) {
-    return dependency.hasProperty('dependencyProject')
 }


### PR DESCRIPTION
Use `from components.release` in place of `artifact artifact("$buildDir/outputs/aar/$projectName-release.aar")` to get proper POM + Gradle module metadata support from the Maven Publish plugin.