### PR TITLE
Add `ofSkeleton` formatters

### DIFF
--- a/javatime/api/javatime.api
+++ b/javatime/api/javatime.api
@@ -4,5 +4,7 @@ public final class dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter 
 	public static fun ofLocalizedDateTime (Landroid/content/Context;Ljava/time/format/FormatStyle;Ljava/time/format/FormatStyle;)Ljava/time/format/DateTimeFormatter;
 	public static fun ofLocalizedTime (Landroid/content/Context;)Ljava/time/format/DateTimeFormatter;
 	public static fun ofLocalizedTime (Landroid/content/Context;Ljava/time/format/FormatStyle;)Ljava/time/format/DateTimeFormatter;
+	public static fun ofSkeleton (Ljava/lang/String;Landroid/content/Context;)Ljava/time/format/DateTimeFormatter;
+	public static fun ofSkeleton (Ljava/lang/String;Ljava/util/Locale;)Ljava/time/format/DateTimeFormatter;
 }
 

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -505,7 +505,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     //endregion
 
     //region ofSkeleton
-    @Test fun ofSkeleton_MMMMdJaLocaleFromContext_formatsToDayFollowedByJapaneseMonth() {
+    @Test fun ofSkeleton_MMMMdJaLocaleFromContext_formatsToJapaneseMonthAndDay() {
         testLocale = Locale.JAPAN
         val formatter = AndroidDateTimeFormatter.ofSkeleton(testContext, "MMMMd")
         assertThat(formatter.format(DATE)).isEqualTo("4月24日")

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -507,23 +507,23 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     //region ofSkeleton
     @Test fun ofSkeleton_MMMMdJaLocaleFromContext_formatsToJapaneseMonthAndDay() {
         testLocale = Locale.JAPAN
-        val formatter = AndroidDateTimeFormatter.ofSkeleton(testContext, "MMMMd")
+        val formatter = AndroidDateTimeFormatter.ofSkeleton("MMMMd", testContext)
         assertThat(formatter.format(DATE)).isEqualTo("4月24日")
     }
 
     @Test fun ofSkeleton_MMMMdUsLocale_formatsToFullMonthFollowedByDay() {
-        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.US, "MMMMd")
+        val formatter = AndroidDateTimeFormatter.ofSkeleton("MMMMd", Locale.US)
         assertThat(formatter.format(DATE)).isEqualTo("April 24")
     }
 
     @Test fun ofSkeleton_MMMMdRuLocale_formatsToDayFollowedByRussianMonth() {
-        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("ru"), "MMMMd")
+        val formatter = AndroidDateTimeFormatter.ofSkeleton("MMMMd", Locale.forLanguageTag("ru"))
         assertThat(formatter.format(DATE)).isEqualTo("24 апреля")
     }
 
     // Unwanted case because coreLibraryDesugaring does not support "L" format:
     @Test fun ofSkeleton_MMMMdFaLocale_formatsToDayFollowedByMonthNumber() {
-        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("fa"), "MMMMd")
+        val formatter = AndroidDateTimeFormatter.ofSkeleton("MMMMd", Locale.forLanguageTag("fa"))
         assertThat(formatter.format(DATE)).isEqualTo("24 4")
     }
     //endregion

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -505,6 +505,12 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     //endregion
 
     //region ofSkeleton
+    @Test fun ofSkeleton_MMMMdJaLocaleFromContext_formatsToDayFollowedByJapaneseMonth() {
+        testLocale = Locale.JAPAN
+        val formatter = AndroidDateTimeFormatter.ofSkeleton(testContext, "MMMMd")
+        assertThat(formatter.format(DATE)).isEqualTo("4月24日")
+    }
+
     @Test fun ofSkeleton_MMMMdUsLocale_formatsToFullMonthFollowedByDay() {
         val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.US, "MMMMd")
         assertThat(formatter.format(DATE)).isEqualTo("April 24")

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -507,18 +507,18 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     //region ofSkeleton
     @Test fun ofSkeleton_MMMMdUsLocale_formatsToFullMonthFollowedByDay() {
         val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.US, "MMMMd")
-        assertThat(formatter.format(JANUARY_4_2020)).isEqualTo("January 4")
+        assertThat(formatter.format(DATE)).isEqualTo("April 24")
     }
 
     @Test fun ofSkeleton_MMMMdRuLocale_formatsToDayFollowedByRussianMonth() {
         val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("ru"), "MMMMd")
-        assertThat(formatter.format(JANUARY_4_2020)).isEqualTo("4 января")
+        assertThat(formatter.format(DATE)).isEqualTo("24 апреля")
     }
 
     // Unwanted case because coreLibraryDesugaring does not support "L" format:
     @Test fun ofSkeleton_MMMMdFaLocale_formatsToDayFollowedByMonthNumber() {
         val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("fa"), "MMMMd")
-        assertThat(formatter.format(JANUARY_4_2020)).isEqualTo("4 1")
+        assertThat(formatter.format(DATE)).isEqualTo("24 4")
     }
     //endregion
 
@@ -545,7 +545,5 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
             Build.VERSION.SDK_INT > 21 -> "04:44:00 PM"
             else -> "16:44:00"
         }
-
-        private val JANUARY_4_2020 = LocalDate.of(2020, Month.JANUARY, 4)
     }
 }

--- a/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/javatime/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -504,6 +504,24 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
     //endregion
 
+    //region ofSkeleton
+    @Test fun ofSkeleton_MMMMdUsLocale_formatsToFullMonthFollowedByDay() {
+        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.US, "MMMMd")
+        assertThat(formatter.format(JANUARY_4_2020)).isEqualTo("January 4")
+    }
+
+    @Test fun ofSkeleton_MMMMdRuLocale_formatsToDayFollowedByRussianMonth() {
+        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("ru"), "MMMMd")
+        assertThat(formatter.format(JANUARY_4_2020)).isEqualTo("4 января")
+    }
+
+    // Unwanted case because coreLibraryDesugaring does not support "L" format:
+    @Test fun ofSkeleton_MMMMdFaLocale_formatsToDayFollowedByMonthNumber() {
+        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("fa"), "MMMMd")
+        assertThat(formatter.format(JANUARY_4_2020)).isEqualTo("4 1")
+    }
+    //endregion
+
     private fun assumeNullableSystemTimeSetting() = assumeFalse(
         "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
         Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING
@@ -527,5 +545,7 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
             Build.VERSION.SDK_INT > 21 -> "04:44:00 PM"
             else -> "16:44:00"
         }
+
+        private val JANUARY_4_2020 = LocalDate.of(2020, Month.JANUARY, 4)
     }
 }

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -269,9 +269,7 @@ public final class AndroidDateTimeFormatter {
     @NonNull
     public static DateTimeFormatter ofSkeleton(@NonNull Locale locale, @NonNull String skeleton) {
         String pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, skeleton);
-        return new DateTimeFormatterBuilder()
-                .appendPattern(pattern)
-                .toFormatter(locale);
+        return DateTimeFormatter.ofPattern(pattern, locale);
     }
     //endregion
 

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -271,9 +271,7 @@ public final class AndroidDateTimeFormatter {
         String pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, skeleton);
         return new DateTimeFormatterBuilder()
                 .appendPattern(pattern)
-                .toFormatter(locale)
-                // TODO: Should this be specified here?
-                .withChronology(IsoChronology.INSTANCE);
+                .toFormatter(locale);
     }
     //endregion
 

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -27,6 +27,7 @@ public final class AndroidDateTimeFormatter {
     private static final String TAG = AndroidDateTimeFormatter.class.getSimpleName();
 
     //region ofLocalizedTime
+
     /**
      * Returns a {@link DateTimeFormatter} that can format the time according to the context's locale and the user's
      * 12-/24-hour clock preference. Convenience for {@link #ofLocalizedTime(Context, FormatStyle)} which uses {@link
@@ -76,6 +77,7 @@ public final class AndroidDateTimeFormatter {
     //endregion
 
     //region ofLocalizedDate
+
     /**
      * Returns a locale specific date format for the ISO chronology.
      * <p>
@@ -103,6 +105,7 @@ public final class AndroidDateTimeFormatter {
     //endregion
 
     //region ofLocalizedDateTime
+
     /**
      * Returns a locale specific date-time formatter for the ISO chronology.
      * <p>
@@ -211,6 +214,7 @@ public final class AndroidDateTimeFormatter {
     }
 
     //region ofSkeleton
+
     /**
      * Returns the best possible localized formatter of the given skeleton for the given context's primary locale. A
      * skeleton is similar to, and uses the same format characters as, a Unicode
@@ -223,9 +227,11 @@ public final class AndroidDateTimeFormatter {
      * {@code es_ES}, we'd have even more extra text: "d 'de' MMMM".
      *
      * <p>This method will automatically correct for grammatical necessity. Given the same "MMMMd" input, the formatter
-     * will use "d LLLL" in the {@code fa_IR} locale, where stand-alone months are necessary. Lengths are preserved
-     * where meaningful, so "Md" would give a different result to "MMMd", say, except in a locale such as {@code ja_JP}
-     * where there is only one length of month.
+     * will use "d LLLL" in the {@code fa_IR} locale, where stand-alone months are necessary. <strong>Warning: core
+     * library desugaring does not currently support formatting with 'L'.</strong>
+     *
+     * <p>Lengths are preserved where meaningful, so "Md" would give a different result to "MMMd", say, except in a
+     * locale such as {@code ja_JP} where there is only one length of month.
      *
      * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
      * in your format string but don't want to make your code specific to any one locale.

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -25,6 +26,7 @@ public final class AndroidDateTimeFormatter {
 
     private static final String TAG = AndroidDateTimeFormatter.class.getSimpleName();
 
+    //region ofLocalizedTime
     /**
      * Returns a {@link DateTimeFormatter} that can format the time according to the context's locale and the user's
      * 12-/24-hour clock preference. Convenience for {@link #ofLocalizedTime(Context, FormatStyle)} which uses {@link
@@ -71,7 +73,9 @@ public final class AndroidDateTimeFormatter {
         return DateTimeFormatter.ofLocalizedTime(timeStyle)
                 .withLocale(contextPrimaryLocale);
     }
+    //endregion
 
+    //region ofLocalizedDate
     /**
      * Returns a locale specific date format for the ISO chronology.
      * <p>
@@ -96,7 +100,9 @@ public final class AndroidDateTimeFormatter {
         return DateTimeFormatter.ofLocalizedDate(dateStyle)
                 .withLocale(extractPrimaryLocale(context));
     }
+    //endregion
 
+    //region ofLocalizedDateTime
     /**
      * Returns a locale specific date-time formatter for the ISO chronology.
      * <p>
@@ -191,6 +197,7 @@ public final class AndroidDateTimeFormatter {
         }
         return null;
     }
+    //endregion
 
     @Nullable
     private static String getSystemTimeSettingAwareShortTimePattern(Context context) {
@@ -202,6 +209,73 @@ public final class AndroidDateTimeFormatter {
             return null;
         }
     }
+
+    //region ofSkeleton
+    /**
+     * Returns the best possible localized formatter of the given skeleton for the given context's primary locale. A
+     * skeleton is similar to, and uses the same format characters as, a Unicode
+     * <a href="http://www.unicode.org/reports/tr35/#Date_Format_Patterns">UTS #35</a> pattern.
+     *
+     * <p>One difference is that order is irrelevant. For example, "MMMMd" will become "MMMM d" in the {@code en_US}
+     * locale, but "d. MMMM" in the {@code de_CH} locale.
+     *
+     * <p>Note also in that second example that the necessary punctuation for German was added. For the same input in
+     * {@code es_ES}, we'd have even more extra text: "d 'de' MMMM".
+     *
+     * <p>This method will automatically correct for grammatical necessity. Given the same "MMMMd" input, the formatter
+     * will use "d LLLL" in the {@code fa_IR} locale, where stand-alone months are necessary. Lengths are preserved
+     * where meaningful, so "Md" would give a different result to "MMMd", say, except in a locale such as {@code ja_JP}
+     * where there is only one length of month.
+     *
+     * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
+     * in your format string but don't want to make your code specific to any one locale.
+     *
+     * @param context the context with which the primary locale is determined
+     * @param skeleton a skeleton as described above
+     * @return a formatter with the localized pattern based on the skeleton
+     */
+    @RequiresApi(18)
+    @NonNull
+    public static DateTimeFormatter ofSkeleton(@NonNull Context context, @NonNull String skeleton) {
+        return ofSkeleton(extractPrimaryLocale(context), skeleton);
+    }
+
+    /**
+     * Returns the best possible localized formatter of the given skeleton for the given locale. A skeleton is similar
+     * to, and uses the same format characters as, a Unicode
+     * <a href="http://www.unicode.org/reports/tr35/#Date_Format_Patterns">UTS #35</a> pattern.
+     *
+     * <p>One difference is that order is irrelevant. For example, "MMMMd" will become "MMMM d" in the {@code en_US}
+     * locale, but "d. MMMM" in the {@code de_CH} locale.
+     *
+     * <p>Note also in that second example that the necessary punctuation for German was added. For the same input in
+     * {@code es_ES}, we'd have even more extra text: "d 'de' MMMM".
+     *
+     * <p>This method will automatically correct for grammatical necessity. Given the same "MMMMd" input, the formatter
+     * will use "d LLLL" in the {@code fa_IR} locale, where stand-alone months are necessary. <strong>Warning: core
+     * library desugaring does not currently support formatting with 'L'.</strong>
+     *
+     * <p>Lengths are preserved where meaningful, so "Md" would give a different result to "MMMd", say, except in a
+     * locale such as {@code ja_JP} where there is only one length of month.
+     *
+     * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
+     * in your format string but don't want to make your code specific to any one locale.
+     *
+     * @param locale the locale into which the skeleton should be localized
+     * @param skeleton a skeleton as described above
+     * @return a formatter with the localized pattern based on the skeleton
+     */
+    @RequiresApi(18)
+    @NonNull
+    public static DateTimeFormatter ofSkeleton(@NonNull Locale locale, @NonNull String skeleton) {
+        String pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, skeleton);
+        return new DateTimeFormatterBuilder()
+                .appendPattern(pattern)
+                .toFormatter(locale)
+                // TODO: Should this be specified here?
+                .withChronology(IsoChronology.INSTANCE);
+    }
+    //endregion
 
     @NonNull
     private static Locale extractPrimaryLocale(@NonNull Context context) {

--- a/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
+++ b/javatime/src/main/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatter.java
@@ -236,14 +236,14 @@ public final class AndroidDateTimeFormatter {
      * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
      * in your format string but don't want to make your code specific to any one locale.
      *
-     * @param context the context with which the primary locale is determined
      * @param skeleton a skeleton as described above
+     * @param context the context with which the primary locale is determined
      * @return a formatter with the localized pattern based on the skeleton
      */
     @RequiresApi(18)
     @NonNull
-    public static DateTimeFormatter ofSkeleton(@NonNull Context context, @NonNull String skeleton) {
-        return ofSkeleton(extractPrimaryLocale(context), skeleton);
+    public static DateTimeFormatter ofSkeleton(@NonNull String skeleton, @NonNull Context context) {
+        return ofSkeleton(skeleton, extractPrimaryLocale(context));
     }
 
     /**
@@ -267,13 +267,13 @@ public final class AndroidDateTimeFormatter {
      * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
      * in your format string but don't want to make your code specific to any one locale.
      *
-     * @param locale the locale into which the skeleton should be localized
      * @param skeleton a skeleton as described above
+     * @param locale the locale into which the skeleton should be localized
      * @return a formatter with the localized pattern based on the skeleton
      */
     @RequiresApi(18)
     @NonNull
-    public static DateTimeFormatter ofSkeleton(@NonNull Locale locale, @NonNull String skeleton) {
+    public static DateTimeFormatter ofSkeleton(@NonNull String skeleton, @NonNull Locale locale) {
         String pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, skeleton);
         return DateTimeFormatter.ofPattern(pattern, locale);
     }

--- a/threetenbp/api/threetenbp.api
+++ b/threetenbp/api/threetenbp.api
@@ -4,5 +4,7 @@ public final class dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTim
 	public static fun ofLocalizedDateTime (Landroid/content/Context;Lorg/threeten/bp/format/FormatStyle;Lorg/threeten/bp/format/FormatStyle;)Lorg/threeten/bp/format/DateTimeFormatter;
 	public static fun ofLocalizedTime (Landroid/content/Context;)Lorg/threeten/bp/format/DateTimeFormatter;
 	public static fun ofLocalizedTime (Landroid/content/Context;Lorg/threeten/bp/format/FormatStyle;)Lorg/threeten/bp/format/DateTimeFormatter;
+	public static fun ofSkeleton (Ljava/lang/String;Landroid/content/Context;)Lorg/threeten/bp/format/DateTimeFormatter;
+	public static fun ofSkeleton (Ljava/lang/String;Ljava/util/Locale;)Lorg/threeten/bp/format/DateTimeFormatter;
 }
 

--- a/threetenbp/src/androidTest/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatterTest.kt
+++ b/threetenbp/src/androidTest/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatterTest.kt
@@ -502,6 +502,29 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     }
     //endregion
 
+    //region ofSkeleton
+    @Test fun ofSkeleton_MMMMdJaLocaleFromContext_formatsToJapaneseMonthAndDay() {
+        testLocale = Locale.JAPAN
+        val formatter = AndroidDateTimeFormatter.ofSkeleton(testContext, "MMMMd")
+        assertThat(formatter.format(DATE)).isEqualTo("4月24日")
+    }
+
+    @Test fun ofSkeleton_MMMMdUsLocale_formatsToFullMonthFollowedByDay() {
+        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.US, "MMMMd")
+        assertThat(formatter.format(DATE)).isEqualTo("April 24")
+    }
+
+    @Test fun ofSkeleton_MMMMdRuLocale_formatsToDayFollowedByRussianMonth() {
+        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("ru"), "MMMMd")
+        assertThat(formatter.format(DATE)).isEqualTo("24 апреля")
+    }
+
+    @Test fun ofSkeleton_MMMMdFaLocale_formatsToDayFollowedByPersianMonth() {
+        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("fa"), "MMMMd")
+        assertThat(formatter.format(DATE)).isEqualTo("24 آوریل")
+    }
+    //endregion
+
     private fun assumeNullableSystemTimeSetting() = assumeFalse(
         "Time setting is not nullable in API ${Build.VERSION.SDK_INT}",
         Build.VERSION.SDK_INT < SDK_INT_NULLABLE_TIME_SETTING

--- a/threetenbp/src/androidTest/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatterTest.kt
+++ b/threetenbp/src/androidTest/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatterTest.kt
@@ -505,22 +505,22 @@ class AndroidDateTimeFormatterTest : TimeSettingTest() {
     //region ofSkeleton
     @Test fun ofSkeleton_MMMMdJaLocaleFromContext_formatsToJapaneseMonthAndDay() {
         testLocale = Locale.JAPAN
-        val formatter = AndroidDateTimeFormatter.ofSkeleton(testContext, "MMMMd")
+        val formatter = AndroidDateTimeFormatter.ofSkeleton("MMMMd", testContext)
         assertThat(formatter.format(DATE)).isEqualTo("4月24日")
     }
 
     @Test fun ofSkeleton_MMMMdUsLocale_formatsToFullMonthFollowedByDay() {
-        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.US, "MMMMd")
+        val formatter = AndroidDateTimeFormatter.ofSkeleton("MMMMd", Locale.US)
         assertThat(formatter.format(DATE)).isEqualTo("April 24")
     }
 
     @Test fun ofSkeleton_MMMMdRuLocale_formatsToDayFollowedByRussianMonth() {
-        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("ru"), "MMMMd")
+        val formatter = AndroidDateTimeFormatter.ofSkeleton("MMMMd", Locale.forLanguageTag("ru"))
         assertThat(formatter.format(DATE)).isEqualTo("24 апреля")
     }
 
     @Test fun ofSkeleton_MMMMdFaLocale_formatsToDayFollowedByPersianMonth() {
-        val formatter = AndroidDateTimeFormatter.ofSkeleton(Locale.forLanguageTag("fa"), "MMMMd")
+        val formatter = AndroidDateTimeFormatter.ofSkeleton("MMMMd", Locale.forLanguageTag("fa"))
         assertThat(formatter.format(DATE)).isEqualTo("24 آوریل")
     }
     //endregion

--- a/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
+++ b/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 import org.threeten.bp.chrono.IsoChronology;
 import org.threeten.bp.format.DateTimeFormatter;
@@ -26,6 +27,7 @@ public final class AndroidDateTimeFormatter {
 
     private static final String TAG = AndroidDateTimeFormatter.class.getSimpleName();
 
+    //region ofLocalizedTime
     /**
      * Returns a {@link DateTimeFormatter} that can format the time according to the context's locale and the user's
      * 12-/24-hour clock preference. Convenience for {@link #ofLocalizedTime(Context, FormatStyle)} which uses {@link
@@ -72,7 +74,9 @@ public final class AndroidDateTimeFormatter {
         return DateTimeFormatter.ofLocalizedTime(timeStyle)
                 .withLocale(contextPrimaryLocale);
     }
+    //endregion
 
+    //region ofLocalizedDate
     /**
      * Returns a locale specific date format for the ISO chronology.
      * <p>
@@ -97,7 +101,9 @@ public final class AndroidDateTimeFormatter {
         return DateTimeFormatter.ofLocalizedDate(dateStyle)
                 .withLocale(extractPrimaryLocale(context));
     }
+    //endregion
 
+    //region ofLocalizedDateTime
     /**
      * Returns a locale specific date-time formatter for the ISO chronology.
      * <p>
@@ -192,6 +198,7 @@ public final class AndroidDateTimeFormatter {
         }
         return null;
     }
+    //endregion
 
     @Nullable
     private static String getSystemTimeSettingAwareShortTimePattern(Context context) {
@@ -203,6 +210,71 @@ public final class AndroidDateTimeFormatter {
             return null;
         }
     }
+
+    //region ofSkeleton
+    /**
+     * Returns the best possible localized formatter of the given skeleton for the given context's primary locale. A
+     * skeleton is similar to, and uses the same format characters as, a Unicode
+     * <a href="http://www.unicode.org/reports/tr35/#Date_Format_Patterns">UTS #35</a> pattern.
+     *
+     * <p>One difference is that order is irrelevant. For example, "MMMMd" will become "MMMM d" in the {@code en_US}
+     * locale, but "d. MMMM" in the {@code de_CH} locale.
+     *
+     * <p>Note also in that second example that the necessary punctuation for German was added. For the same input in
+     * {@code es_ES}, we'd have even more extra text: "d 'de' MMMM".
+     *
+     * <p>This method will automatically correct for grammatical necessity. Given the same "MMMMd" input, the formatter
+     * will use "d LLLL" in the {@code fa_IR} locale, where stand-alone months are necessary. Lengths are preserved
+     * where meaningful, so "Md" would give a different result to "MMMd", say, except in a locale such as {@code ja_JP}
+     * where there is only one length of month.
+     *
+     * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
+     * in your format string but don't want to make your code specific to any one locale.
+     *
+     * @param context the context with which the primary locale is determined
+     * @param skeleton a skeleton as described above
+     * @return a formatter with the localized pattern based on the skeleton
+     */
+    @RequiresApi(18)
+    @NonNull
+    public static DateTimeFormatter ofSkeleton(@NonNull Context context, @NonNull String skeleton) {
+        return ofSkeleton(extractPrimaryLocale(context), skeleton);
+    }
+
+    /**
+     * Returns the best possible localized formatter of the given skeleton for the given locale. A skeleton is similar
+     * to, and uses the same format characters as, a Unicode
+     * <a href="http://www.unicode.org/reports/tr35/#Date_Format_Patterns">UTS #35</a> pattern.
+     *
+     * <p>One difference is that order is irrelevant. For example, "MMMMd" will become "MMMM d" in the {@code en_US}
+     * locale, but "d. MMMM" in the {@code de_CH} locale.
+     *
+     * <p>Note also in that second example that the necessary punctuation for German was added. For the same input in
+     * {@code es_ES}, we'd have even more extra text: "d 'de' MMMM".
+     *
+     * <p>This method will automatically correct for grammatical necessity. Given the same "MMMMd" input, the formatter
+     * will use "d LLLL" in the {@code fa_IR} locale, where stand-alone months are necessary. <strong>Warning: core
+     * library desugaring does not currently support formatting with 'L'.</strong>
+     *
+     * <p>Lengths are preserved where meaningful, so "Md" would give a different result to "MMMd", say, except in a
+     * locale such as {@code ja_JP} where there is only one length of month.
+     *
+     * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
+     * in your format string but don't want to make your code specific to any one locale.
+     *
+     * @param locale the locale into which the skeleton should be localized
+     * @param skeleton a skeleton as described above
+     * @return a formatter with the localized pattern based on the skeleton
+     */
+    @RequiresApi(18)
+    @NonNull
+    public static DateTimeFormatter ofSkeleton(@NonNull Locale locale, @NonNull String skeleton) {
+        String pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, skeleton);
+        return new DateTimeFormatterBuilder()
+                .appendPattern(pattern)
+                .toFormatter(locale);
+    }
+    //endregion
 
     @NonNull
     private static Locale extractPrimaryLocale(@NonNull Context context) {

--- a/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
+++ b/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
@@ -235,14 +235,14 @@ public final class AndroidDateTimeFormatter {
      * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
      * in your format string but don't want to make your code specific to any one locale.
      *
-     * @param context the context with which the primary locale is determined
      * @param skeleton a skeleton as described above
+     * @param context the context with which the primary locale is determined
      * @return a formatter with the localized pattern based on the skeleton
      */
     @RequiresApi(18)
     @NonNull
-    public static DateTimeFormatter ofSkeleton(@NonNull Context context, @NonNull String skeleton) {
-        return ofSkeleton(extractPrimaryLocale(context), skeleton);
+    public static DateTimeFormatter ofSkeleton(@NonNull String skeleton, @NonNull Context context) {
+        return ofSkeleton(skeleton, extractPrimaryLocale(context));
     }
 
     /**
@@ -264,13 +264,13 @@ public final class AndroidDateTimeFormatter {
      * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
      * in your format string but don't want to make your code specific to any one locale.
      *
-     * @param locale the locale into which the skeleton should be localized
      * @param skeleton a skeleton as described above
+     * @param locale the locale into which the skeleton should be localized
      * @return a formatter with the localized pattern based on the skeleton
      */
     @RequiresApi(18)
     @NonNull
-    public static DateTimeFormatter ofSkeleton(@NonNull Locale locale, @NonNull String skeleton) {
+    public static DateTimeFormatter ofSkeleton(@NonNull String skeleton, @NonNull Locale locale) {
         String pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, skeleton);
         return DateTimeFormatter.ofPattern(pattern, locale);
     }

--- a/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
+++ b/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
@@ -28,6 +28,7 @@ public final class AndroidDateTimeFormatter {
     private static final String TAG = AndroidDateTimeFormatter.class.getSimpleName();
 
     //region ofLocalizedTime
+
     /**
      * Returns a {@link DateTimeFormatter} that can format the time according to the context's locale and the user's
      * 12-/24-hour clock preference. Convenience for {@link #ofLocalizedTime(Context, FormatStyle)} which uses {@link
@@ -77,6 +78,7 @@ public final class AndroidDateTimeFormatter {
     //endregion
 
     //region ofLocalizedDate
+
     /**
      * Returns a locale specific date format for the ISO chronology.
      * <p>
@@ -104,6 +106,7 @@ public final class AndroidDateTimeFormatter {
     //endregion
 
     //region ofLocalizedDateTime
+
     /**
      * Returns a locale specific date-time formatter for the ISO chronology.
      * <p>
@@ -212,6 +215,7 @@ public final class AndroidDateTimeFormatter {
     }
 
     //region ofSkeleton
+
     /**
      * Returns the best possible localized formatter of the given skeleton for the given context's primary locale. A
      * skeleton is similar to, and uses the same format characters as, a Unicode
@@ -253,11 +257,9 @@ public final class AndroidDateTimeFormatter {
      * {@code es_ES}, we'd have even more extra text: "d 'de' MMMM".
      *
      * <p>This method will automatically correct for grammatical necessity. Given the same "MMMMd" input, the formatter
-     * will use "d LLLL" in the {@code fa_IR} locale, where stand-alone months are necessary. <strong>Warning: core
-     * library desugaring does not currently support formatting with 'L'.</strong>
-     *
-     * <p>Lengths are preserved where meaningful, so "Md" would give a different result to "MMMd", say, except in a
-     * locale such as {@code ja_JP} where there is only one length of month.
+     * will use "d LLLL" in the {@code fa_IR} locale, where stand-alone months are necessary. <p>Lengths are preserved
+     * where meaningful, so "Md" would give a different result to "MMMd", say, except in a locale such as {@code ja_JP}
+     * where there is only one length of month.
      *
      * <p>This method will only use patterns that are in CLDR, and is useful whenever you know what elements you want
      * in your format string but don't want to make your code specific to any one locale.

--- a/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
+++ b/threetenbp/src/main/java/dev/drewhamilton/androidtime/threetenbp/format/AndroidDateTimeFormatter.java
@@ -270,9 +270,7 @@ public final class AndroidDateTimeFormatter {
     @NonNull
     public static DateTimeFormatter ofSkeleton(@NonNull Locale locale, @NonNull String skeleton) {
         String pattern = android.text.format.DateFormat.getBestDateTimePattern(locale, skeleton);
-        return new DateTimeFormatterBuilder()
-                .appendPattern(pattern)
-                .toFormatter(locale);
+        return DateTimeFormatter.ofPattern(pattern, locale);
     }
     //endregion
 


### PR DESCRIPTION
This allows creating DateTimeFormatters based on "skeleton" patterns which get localized into actual date-time format patterns by `android.text.format.DateFormat.getBestDateTimePattern`.

Known issue: `java.time.DateTimeFormatter`s which get standalone symbols like 'L' in their pattern don't format nicely due to [lack of support](https://developer.android.com/studio/write/java8-support-table#java-time-customizations) from core library desugaring. Hopefully this can be [fixed in the future](https://issuetracker.google.com/issues/157926127#comment11).