### PR TITLE
Run CI only on 5 emulators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,8 @@ jobs:
 
     strategy:
       matrix:
-        api-level: [21, 22, 23, 24, 25, 26, 27, 28, 29]
+        # Limit to 5 (GitHub max parallel MacOS machines):
+        api-level: [21, 22, 25, 28, 29]
 
     steps:
       - name: Check out the repo


### PR DESCRIPTION
GitHub limits us to 5 parallel MacOS builds, so only test on 5 emulators to make the builds faster.