### PR TITLE
Prevent tests on APIs 22–27

### DIFF
--- a/datetimeformatters/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/datetimeformatters/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -16,6 +16,7 @@ import java.util.Locale
 import java.util.TimeZone
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Date as JavaUtilDate
@@ -609,5 +610,17 @@ class AndroidDateTimeFormatterTest(
                 TIME_SETTING_24 -> shortTime24
                 else -> throw AssertionError("Invalid preferred time setting: $preferredTimeSetting")
             }
+    }
+
+    companion object {
+        /**
+         * This class has strange behavior on APIs 22 through 27, inconsistently using the wrong
+         * 12/24 setting on short and/or medium times despite editing the system setting.
+         * Preemptively fail on these APIs to avoid confusion.
+         */
+        @BeforeClass
+        @JvmStatic fun preventApis22Through27() {
+            assertThat(Build.VERSION.SDK_INT).isNotIn(22..27)
+        }
     }
 }

--- a/datetimeformatters/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
+++ b/datetimeformatters/src/androidTest/java/dev/drewhamilton/androidtime/format/AndroidDateTimeFormatterTest.kt
@@ -439,12 +439,7 @@ class AndroidDateTimeFormatterTest(
                 else -> "06:01 PM"
             },
             shortTime24 = "18:01",
-            mediumTime = when {
-                Build.VERSION.SDK_INT >= 26 -> "18:01:00"
-                Build.VERSION.SDK_INT >= 23 -> "6:01:00 PM"
-                Build.VERSION.SDK_INT >= 22 -> "06:01:00 PM"
-                else -> "18:01:00"
-            },
+            mediumTime = "18:01:00",
             longTime = when {
                 Build.VERSION.SDK_INT >= 21 -> "18:01:00 GMT-05:00"
                 else -> "18:01:00 CDT"
@@ -468,11 +463,7 @@ class AndroidDateTimeFormatterTest(
             preferredTimeSetting = TIME_SETTING_24,
             shortTime12 = "6:01 PM",
             shortTime24 = "18:01",
-            mediumTime = when {
-                Build.VERSION.SDK_INT >= 26 -> "18:01:00"
-                Build.VERSION.SDK_INT >= 22 -> "6:01:00 PM"
-                else -> "18:01:00"
-            },
+            mediumTime = "18:01:00",
             longTime = when {
                 Build.VERSION.SDK_INT >= 21 -> "18:01:00 GMT-05:00"
                 else -> "18:01:00 CDT"
@@ -529,11 +520,7 @@ class AndroidDateTimeFormatterTest(
             preferredTimeSetting = TIME_SETTING_24,
             shortTime12 = "午後6:01",
             shortTime24 = "18:01",
-            mediumTime = when {
-                Build.VERSION.SDK_INT >= 26 -> "18:01:00"
-                Build.VERSION.SDK_INT >= 22 -> "午後6:01:00"
-                else -> "18:01:00"
-            },
+            mediumTime = "18:01:00",
             longTime = when {
                 Build.VERSION.SDK_INT >= 21 -> "18:01:00 GMT-05:00"
                 else -> "18:01:00 CDT"
@@ -555,12 +542,7 @@ class AndroidDateTimeFormatterTest(
                 else -> "6:01 после полудня"
             },
             shortTime24 = "18:01",
-            mediumTime = when {
-                Build.VERSION.SDK_INT >= 26 -> "18:01:00"
-                Build.VERSION.SDK_INT >= 24 -> "6:01:00 ПП"
-                Build.VERSION.SDK_INT >= 22 -> "6:01:00 PM"
-                else -> "18:01:00"
-            },
+            mediumTime = "18:01:00",
             longTime = when {
                 Build.VERSION.SDK_INT >= 21 -> "18:01:00 GMT-05:00"
                 else -> "18:01:00 CDT"
@@ -586,11 +568,7 @@ class AndroidDateTimeFormatterTest(
             preferredTimeSetting = TIME_SETTING_24,
             shortTime12 = "6:01 بعدازظهر",
             shortTime24 = "18:01",
-            mediumTime = when {
-                Build.VERSION.SDK_INT >= 26 -> "18:01:00"
-                Build.VERSION.SDK_INT >= 22 -> "6:01:00 بعدازظهر"
-                else -> "18:01:00"
-            },
+            mediumTime = "18:01:00",
             longTime = when {
                 Build.VERSION.SDK_INT >= 21 -> "18:01:00 (GMT-05:00)"
                 else -> "18:01:00 (CDT)"


### PR DESCRIPTION
These APIs seem to inconsistently use 12 hour time by default for locales that should default to 24 hour time. It's confusing and buggy, and these APIs are old enough now to not worry about it too much.