### PR TITLE
AGP 8.7.0-alpha03

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-agp = "8.4.2"
+agp = "8.7.0-alpha03"
 androidx-compose-bom = "2024.06.00"
 kotlin = "2.0.0"
 


### PR DESCRIPTION
Contains a fix for a desugaring lint bug in AGP 8.5 and 8.6, allowing upgrade from 8.4.2.