### PR TITLE
Allow the whole CI matrix to run even if one build fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         api-level: [ 29, 30, 32 ]
         arch: [ x86_64 ]


### PR DESCRIPTION
Failures for this library are often OS level-specific, so it's worth seeing when this is the case.